### PR TITLE
ci: update workflow dispatch to dev branch

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -16,13 +16,11 @@ on:
   schedule:
     - cron: '0 10 * * *'
   push:
-    branches:
-      - '**'
     tags:
       - 'v*.*.*'
   pull_request:
     branches:
-      - 'main'
+      - 'dev'
   workflow_dispatch:
 jobs:
   api-docker-deploy:


### PR DESCRIPTION
- Change workflow_dispatch job to run on dev branch instead of main
- Remove branches: '**' from push event to reduce unnecessary builds