### PR TITLE
refactor(api): move common types to separate module 

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/__about__.py
+++ b/packages/markitdown-api/src/markitdown_api/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "0.0.10"
+__version__ = "0.0.11"

--- a/packages/markitdown-api/src/markitdown_api/app.py
+++ b/packages/markitdown-api/src/markitdown_api/app.py
@@ -15,7 +15,7 @@ app = FastAPI(
     Text-based formats (CSV, JSON, XML),ZIP files (iterates over contents),Youtube URLs,EPubs and more!
     """,
     version=markitdown_version + "-" + __about__.__version__,
-    contact={"name": "Ahoo Wang", "url": "https://github.com/Ahoo-Wang"},
+    contact={"name": "Ahoo Wang", "url": "https://github.com/Ahoo-Wang/markitdown"},
 )
 
 app.include_router(convert_uri.router)

--- a/packages/markitdown-api/src/markitdown_api/commons.py
+++ b/packages/markitdown-api/src/markitdown_api/commons.py
@@ -2,29 +2,9 @@ import os
 from typing import Optional
 
 from openai import OpenAI
-from pydantic import BaseModel, Field
-from starlette.responses import Response
 
 from markitdown import MarkItDown
-from markitdown._llm_utils import get_llm_prompt
-
-
-class ConvertResult(BaseModel):
-    title: Optional[str]
-    markdown: str
-
-
-class MarkdownResponse(Response):
-    media_type = "text/markdown"
-
-
-class LlmOptions(BaseModel):
-    open_ai_base_url: str | None = Field(
-        default=None, description="OpenAI API base URL"
-    )
-    open_ai_api_key: str | None = Field(default=None, description="OpenAI API key")
-    model: str | None = Field(default=None, description="LLM model")
-    prompt: str = get_llm_prompt()
+from markitdown_api.types import LlmOptions
 
 
 def is_blank(s: str) -> bool:
@@ -38,7 +18,7 @@ def blank_then_none(s: str) -> str | None:
 
 
 def _build_markitdown(llm_options: Optional[LlmOptions] = None) -> MarkItDown:
-    base_url = api_key = llm_model = prompt = None
+    base_url = api_key = llm_model = None
     if llm_options:
         base_url = blank_then_none(llm_options.open_ai_base_url)
         api_key = blank_then_none(llm_options.open_ai_api_key)

--- a/packages/markitdown-api/src/markitdown_api/convert_file.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_file.py
@@ -2,22 +2,12 @@ from io import BufferedReader
 from typing import Annotated
 
 from fastapi import APIRouter, UploadFile, File, Form
-from pydantic import BaseModel, Field
 
 from markitdown import StreamInfo
-from markitdown_api.commons import (
-    LlmOptions,
-    ConvertResult,
-    _build_markitdown,
-    MarkdownResponse,
-)
+from markitdown_api.commons import _build_markitdown
+from markitdown_api.types import ConvertResult, LlmOptions, MarkdownResponse
 
 TAG = "Convert File"
-
-
-class ConvertFileRequest(BaseModel):
-    llm: LlmOptions | None = Field(default=None, description="LLM options")
-
 
 router = APIRouter(
     prefix="/convert/file",

--- a/packages/markitdown-api/src/markitdown_api/convert_text.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_text.py
@@ -3,17 +3,17 @@ from pydantic import BaseModel, Field
 from io import BytesIO
 
 from markitdown import StreamInfo
-from markitdown_api.commons import LlmOptions, ConvertResult, _build_markitdown
+from markitdown_api.commons import _build_markitdown
+from markitdown_api.types import ConvertRequest, ConvertResult
 
 TAG = "Convert Text"
 
 
-class ConvertTextRequest(BaseModel):
+class ConvertTextRequest(ConvertRequest):
     text: str
     mimetype: str = Field(
         default="text/plain", description="MIME type of the input text"
     )
-    llm: LlmOptions | None = Field(default=None, description="LLM options")
 
 
 router = APIRouter(

--- a/packages/markitdown-api/src/markitdown_api/convert_uri.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_uri.py
@@ -4,10 +4,13 @@ from fastapi import Query, Body, APIRouter
 from pydantic import BaseModel, Field
 
 from markitdown_api.commons import (
-    MarkdownResponse,
+    _build_markitdown,
+)
+from markitdown_api.types import (
+    ConvertRequest,
     LlmOptions,
     ConvertResult,
-    _build_markitdown,
+    MarkdownResponse,
 )
 
 TAG = "Convert Uri"
@@ -22,9 +25,8 @@ URI_PATTERN = "^(file|data|http|https)://"
 URI_QUERY = Query(description=URI_DESCRIPTION, pattern=URI_PATTERN)
 
 
-class ConvertUrlRequest(BaseModel):
+class ConvertUrlRequest(ConvertRequest):
     uri: str = Field(description=URI_DESCRIPTION, pattern=URI_PATTERN)
-    llm: LlmOptions | None = Field(default=None, description="LLM options")
 
 
 router = APIRouter(prefix="/convert/uri", tags=[TAG])

--- a/packages/markitdown-api/src/markitdown_api/types.py
+++ b/packages/markitdown-api/src/markitdown_api/types.py
@@ -1,0 +1,26 @@
+from typing import Optional
+from pydantic import BaseModel, Field
+from starlette.responses import Response
+from markitdown._llm_utils import get_llm_prompt
+
+
+class LlmOptions(BaseModel):
+    open_ai_base_url: str | None = Field(
+        default=None, description="OpenAI API base URL"
+    )
+    open_ai_api_key: str | None = Field(default=None, description="OpenAI API key")
+    model: str | None = Field(default=None, description="LLM model")
+    prompt: str = get_llm_prompt()
+
+
+class ConvertRequest(BaseModel):
+    llm: LlmOptions | None = Field(default=None, description="LLM options")
+
+
+class MarkdownResponse(Response):
+    media_type = "text/markdown"
+
+
+class ConvertResult(BaseModel):
+    title: Optional[str]
+    markdown: str


### PR DESCRIPTION
- Extract LlmOptions, ConvertRequest, MarkdownResponse, and ConvertResult to markitdown_api/types.py
- Update imports in other modules to use the new location for these types
- Simplify _build_markitdown function by removing prompt parameter