### PR TITLE
refactor(api): rename types module to api_types and update type annotations

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/api_types.py
+++ b/packages/markitdown-api/src/markitdown_api/api_types.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from pydantic import BaseModel, Field
 from starlette.responses import Response
 from markitdown._llm_utils import get_llm_prompt
@@ -22,5 +21,5 @@ class MarkdownResponse(Response):
 
 
 class ConvertResult(BaseModel):
-    title: Optional[str]
+    title: str | None = Field(default=None)
     markdown: str

--- a/packages/markitdown-api/src/markitdown_api/commons.py
+++ b/packages/markitdown-api/src/markitdown_api/commons.py
@@ -4,7 +4,7 @@ from typing import Optional
 from openai import OpenAI
 
 from markitdown import MarkItDown
-from markitdown_api.types import LlmOptions
+from markitdown_api.api_types import LlmOptions
 
 
 def is_blank(s: str) -> bool:

--- a/packages/markitdown-api/src/markitdown_api/convert_file.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_file.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, UploadFile, File, Form
 
 from markitdown import StreamInfo
 from markitdown_api.commons import _build_markitdown
-from markitdown_api.types import ConvertResult, LlmOptions, MarkdownResponse
+from markitdown_api.api_types import ConvertResult, LlmOptions, MarkdownResponse
 
 TAG = "Convert File"
 

--- a/packages/markitdown-api/src/markitdown_api/convert_text.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_text.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field
 from io import BytesIO
 
+from fastapi import APIRouter, HTTPException
+from pydantic import Field
+
 from markitdown import StreamInfo
+from markitdown_api.api_types import ConvertRequest, ConvertResult
 from markitdown_api.commons import _build_markitdown
-from markitdown_api.types import ConvertRequest, ConvertResult
 
 TAG = "Convert Text"
 

--- a/packages/markitdown-api/src/markitdown_api/convert_uri.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_uri.py
@@ -1,16 +1,16 @@
 from typing import Annotated
 
 from fastapi import Query, Body, APIRouter
-from pydantic import BaseModel, Field
+from pydantic import Field
 
-from markitdown_api.commons import (
-    _build_markitdown,
-)
-from markitdown_api.types import (
+from markitdown_api.api_types import (
     ConvertRequest,
     LlmOptions,
     ConvertResult,
     MarkdownResponse,
+)
+from markitdown_api.commons import (
+    _build_markitdown,
 )
 
 TAG = "Convert Uri"


### PR DESCRIPTION
- Rename 'types.py' to 'api_types.py' to better reflect its contents
- Update import statements in affected modules
- Replace 'Optional[str]' with 'str | None' for improved readability