### PR TITLE
refactor(markitdown-api): bump version to 0.0.12 and adjust API endpoints

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/__about__.py
+++ b/packages/markitdown-api/src/markitdown_api/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "0.0.11"
+__version__ = "0.0.12"

--- a/packages/markitdown-api/src/markitdown_api/convert_file.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_file.py
@@ -37,7 +37,7 @@ def _convert_file(
         )
 
 
-@router.post(path="/", response_model=ConvertResult)
+@router.post(path="", response_model=ConvertResult)
 async def convert_file(
     file: Annotated[UploadFile, File()],
     openai_base_url: Annotated[str, Form()] = "",

--- a/packages/markitdown-api/src/markitdown_api/convert_text.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_text.py
@@ -23,7 +23,7 @@ router = APIRouter(
 )
 
 
-@router.post(path="/", response_model=ConvertResult)
+@router.post(path="", response_model=ConvertResult)
 async def convert_text(request: ConvertTextRequest):
     if not request.text or len(request.text) > 100_000:
         raise HTTPException(status_code=400, detail="Invalid input text length")

--- a/packages/markitdown-api/src/markitdown_api/convert_uri.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_uri.py
@@ -40,7 +40,7 @@ def _convert_uri(uri: str, llm_options: LlmOptions | None = None) -> ConvertResu
     return ConvertResult(title=convert_result.title, markdown=convert_result.markdown)
 
 
-@router.post(path="/", response_model=ConvertResult)
+@router.post(path="", response_model=ConvertResult)
 async def convert_uri(
     request: Annotated[
         ConvertUrlRequest, Body(examples=[{"uri": "https://wow.ahoo.me/"}])
@@ -49,7 +49,7 @@ async def convert_uri(
     return _convert_uri(request.uri, request.llm)
 
 
-@router.get(path="/", response_model=ConvertResult)
+@router.get(path="", response_model=ConvertResult)
 async def convert_uri(uri: Annotated[str, URI_QUERY]):
     """
     The Uniform Resource Identifier (URI) to be converted.


### PR DESCRIPTION

- Update package version from 0.0.11 to 0.0.12
- Remove trailing slashes from API endpoint paths for consistency
- Adjust function definitions to improve readability and reduce line length