### PR TITLE
build(markitdown-api): update markitdown dependency to local path

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -77,7 +77,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
-          context: packages/markitdown-api
+          context: packages
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/packages/Dockerfile
+++ b/packages/Dockerfile
@@ -15,13 +15,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Cleanup
 RUN rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
+
 COPY . /app
-RUN pip --no-cache-dir install \
-    /app/markitdown[all] \
-    /app/markitdown-api
 
 WORKDIR /app/markitdown-api
+RUN pip --no-cache-dir install .
+
+WORKDIR /markitdown-api
 
 # Default USERID and GROUPID
 ARG USERID=nobody
@@ -31,4 +31,4 @@ USER $USERID:$GROUPID
 
 EXPOSE 8000
 
-CMD ["uvicorn", "markitdown_api.app:app", "--host", "0.0.0.0", "--port", "8000"]
+ENTRYPOINT ["markitdown-api"]

--- a/packages/Dockerfile
+++ b/packages/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Cleanup
 RUN rm -rf /var/lib/apt/lists/*
 
-COPY .. /app
+COPY . /app
 RUN pip --no-cache-dir install /app/markitdown-api
 
 WORKDIR /markitdown-api

--- a/packages/Dockerfile
+++ b/packages/Dockerfile
@@ -15,10 +15,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Cleanup
 RUN rm -rf /var/lib/apt/lists/*
 
+WORKDIR /app
 COPY . /app
-RUN pip --no-cache-dir install /app/markitdown-api
+RUN pip --no-cache-dir install \
+    /app/markitdown[all] \
+    /app/markitdown-api
 
-WORKDIR /markitdown-api
+WORKDIR /app/markitdown-api
 
 # Default USERID and GROUPID
 ARG USERID=nobody

--- a/packages/markitdown-api/Dockerfile
+++ b/packages/markitdown-api/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Cleanup
 RUN rm -rf /var/lib/apt/lists/*
 
-COPY . /app
-RUN pip --no-cache-dir install /app
+COPY .. /app
+RUN pip --no-cache-dir install /app/markitdown-api
 
 WORKDIR /markitdown-api
 

--- a/packages/markitdown-api/pyproject.toml
+++ b/packages/markitdown-api/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-    "markitdown[all] @ git+https://github.com/Ahoo-Wang/markitdown.git@dev#subdirectory=packages/markitdown",
+    "markitdown[all] @ file:../markitdown",
     "fastapi[standard]>=0.115.14",
     "uvicorn[standard]>=0.35.0",
     "openai>=1.93.0"


### PR DESCRIPTION
- Change markitdown dependency from git+https to file:../markitdown
- This update allows using a local version of the markitdown package