### PR TITLE
feat(api): add HTTP conversion endpoint and refactor common functionality

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/__about__.py
+++ b/packages/markitdown-api/src/markitdown_api/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "0.0.12"
+__version__ = "0.0.15"

--- a/packages/markitdown-api/src/markitdown_api/api_types.py
+++ b/packages/markitdown-api/src/markitdown_api/api_types.py
@@ -15,6 +15,9 @@ class LlmOptions(BaseModel):
 class ConvertRequest(BaseModel):
     llm: LlmOptions | None = Field(default=None, description="LLM options")
 
+    def get_llm_options(self) -> str:
+        return self.llm.prompt if self.llm else ""
+
 
 class MarkdownResponse(Response):
     media_type = "text/markdown"

--- a/packages/markitdown-api/src/markitdown_api/app.py
+++ b/packages/markitdown-api/src/markitdown_api/app.py
@@ -4,7 +4,13 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from markitdown.__about__ import __version__ as markitdown_version
-from markitdown_api import convert_uri, convert_text, convert_file, __about__
+from markitdown_api import (
+    convert_uri,
+    convert_text,
+    convert_file,
+    convert_http,
+    __about__,
+)
 
 app = FastAPI(
     title="MarkItDown API",
@@ -21,6 +27,7 @@ app = FastAPI(
 app.include_router(convert_uri.router)
 app.include_router(convert_text.router)
 app.include_router(convert_file.router)
+app.include_router(convert_http.router)
 
 
 async def file_not_found_handler(request: Request, exc: FileNotFoundError):

--- a/packages/markitdown-api/src/markitdown_api/commons.py
+++ b/packages/markitdown-api/src/markitdown_api/commons.py
@@ -17,7 +17,7 @@ def blank_then_none(s: str) -> str | None:
     return s
 
 
-def _build_markitdown(llm_options: Optional[LlmOptions] = None) -> MarkItDown:
+def build_markitdown(llm_options: Optional[LlmOptions] = None) -> MarkItDown:
     base_url = api_key = llm_model = None
     if llm_options:
         base_url = blank_then_none(llm_options.open_ai_base_url)

--- a/packages/markitdown-api/src/markitdown_api/convert_file.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_file.py
@@ -4,7 +4,7 @@ from typing import Annotated
 from fastapi import APIRouter, UploadFile, File, Form
 
 from markitdown import StreamInfo
-from markitdown_api.commons import _build_markitdown
+from markitdown_api.commons import build_markitdown
 from markitdown_api.api_types import ConvertResult, LlmOptions, MarkdownResponse
 
 TAG = "Convert File"
@@ -29,7 +29,7 @@ def _convert_file(
         model=llm_model,
     )
     with BufferedReader(file.file) as buffered_reader:
-        convert_result = _build_markitdown(openai_options).convert_stream(
+        convert_result = build_markitdown(openai_options).convert_stream(
             buffered_reader, stream_info=stream_info, llm_prompt=llm_prompt
         )
         return ConvertResult(

--- a/packages/markitdown-api/src/markitdown_api/convert_http.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_http.py
@@ -1,0 +1,58 @@
+from typing import Annotated
+
+import requests
+from fastapi import Body, APIRouter
+from markitdown_api.api_types import (
+    ConvertRequest,
+    ConvertResult,
+    MarkdownResponse,
+)
+from markitdown_api.commons import build_markitdown
+from pydantic import Field
+
+TAG = "Convert Http"
+
+HTTP_DESCRIPTION = """
+The Uniform Resource Identifier (URI) to be converted.
+Supported schemes are: http:, https:.
+Example: https://example.com/document.docx
+"""
+HTTP_PATTERN = "^(http|https)://"
+
+
+class ConvertHttpRequest(ConvertRequest):
+    url: str = Field(description=HTTP_DESCRIPTION, pattern=HTTP_PATTERN)
+    headers: dict | None = Field(
+        default=None,
+        description="Headers to be passed to the HTTP request. "
+        "Example: {'Authorization': 'Bearer <token>'}",
+    )
+
+
+router = APIRouter(prefix="/convert/http", tags=[TAG])
+
+
+def _convert_http(request: ConvertHttpRequest) -> ConvertResult:
+    response = requests.get(request.url, headers=request.headers)
+    convert_result = build_markitdown(request.llm).convert_response(
+        response, llm_prompt=request.get_llm_options()
+    )
+    return ConvertResult(title=convert_result.title, markdown=convert_result.markdown)
+
+
+@router.post(path="", response_model=ConvertResult)
+async def convert_http(
+    request: Annotated[
+        ConvertHttpRequest, Body(examples=[{"url": "https://wow.ahoo.me/"}])
+    ]
+):
+    return _convert_http(request)
+
+
+@router.post(path="/markdown", response_class=MarkdownResponse)
+async def convert_uri_markdown(
+    request: Annotated[
+        ConvertHttpRequest, Body(examples=[{"url": "https://wow.ahoo.me/"}])
+    ]
+):
+    return _convert_http(request).markdown

--- a/packages/markitdown-api/src/markitdown_api/convert_text.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_text.py
@@ -5,7 +5,7 @@ from pydantic import Field
 
 from markitdown import StreamInfo
 from markitdown_api.api_types import ConvertRequest, ConvertResult
-from markitdown_api.commons import _build_markitdown
+from markitdown_api.commons import build_markitdown
 
 TAG = "Convert Text"
 
@@ -33,7 +33,7 @@ async def convert_text(request: ConvertTextRequest):
 
     stream_info = StreamInfo(mimetype=request.mimetype)
     llm_prompt = request.llm.prompt if request.llm else ""
-    convert_result = _build_markitdown(request.llm).convert_stream(
+    convert_result = build_markitdown(request.llm).convert_stream(
         stream=binary_io, stream_info=stream_info, llm_prompt=llm_prompt
     )
 

--- a/packages/markitdown-api/src/markitdown_api/convert_uri.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_uri.py
@@ -9,9 +9,7 @@ from markitdown_api.api_types import (
     ConvertResult,
     MarkdownResponse,
 )
-from markitdown_api.commons import (
-    _build_markitdown,
-)
+from markitdown_api.commons import build_markitdown
 
 TAG = "Convert Uri"
 
@@ -34,7 +32,7 @@ router = APIRouter(prefix="/convert/uri", tags=[TAG])
 
 def _convert_uri(uri: str, llm_options: LlmOptions | None = None) -> ConvertResult:
     llm_prompt = llm_options.prompt if llm_options else ""
-    convert_result = _build_markitdown(llm_options).convert_uri(
+    convert_result = build_markitdown(llm_options).convert_uri(
         uri, llm_prompt=llm_prompt
     )
     return ConvertResult(title=convert_result.title, markdown=convert_result.markdown)


### PR DESCRIPTION
- Add new convert_http.py file implementing HTTP conversion functionality
- Refactor _build_markitdown function to build_markitdown and move to commons.py
- Update convert_file.py, convert_text.py, and convert_uri.py to use new build_markitdown function
- Add get_llm_options method to ConvertRequest class
- Update app.py to include new convert_http router