### PR TITLE
feat(api): add data size information to HTTP convert response

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/__about__.py
+++ b/packages/markitdown-api/src/markitdown_api/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "0.0.18"
+__version__ = "0.0.19"


### PR DESCRIPTION
- Update ConvertHttpResponse to include mime_type and data_size fields
- Modify _convert_http function to calculate and return data size
- Update endpoint to use ConvertHttpResponse as the response model
- Bump version to 0.0.19