### PR TITLE
fix(api-converter): prevent null pointer exception

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/__about__.py
+++ b/packages/markitdown-api/src/markitdown_api/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"

--- a/packages/markitdown-api/src/markitdown_api/api_converter.py
+++ b/packages/markitdown-api/src/markitdown_api/api_converter.py
@@ -38,7 +38,7 @@ class ApiConverter:
             storage_result = StoragerRegistrar().storage(
                 self.request.storage, self.metadata, converted_result
             )
-            result = None
+            result.markdown = ""
 
         return ConvertResponse(
             metadata=self.metadata,


### PR DESCRIPTION
- Update version to 0.2.6
- Initialize result.markdown to empty string to avoid null pointer exception