### PR TITLE
feat(api): add CSS selector support for HTML conversion

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/__about__.py
+++ b/packages/markitdown-api/src/markitdown_api/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "0.2.6"
+__version__ = "0.2.8"

--- a/packages/markitdown-api/src/markitdown_api/api_converter.py
+++ b/packages/markitdown-api/src/markitdown_api/api_converter.py
@@ -27,6 +27,7 @@ class ApiConverter:
         converted_result = self._internal_convert(
             llm_prompt=self.request.get_llm_prompt(),
             keep_data_uris=self.request.keep_data_uris,
+            selector=self.request.html.selector if self.request.html else None,
         )
         markdown = remove_all_zw_chars(converted_result.markdown)
         result = ConvertResult(

--- a/packages/markitdown-api/src/markitdown_api/api_types.py
+++ b/packages/markitdown-api/src/markitdown_api/api_types.py
@@ -17,9 +17,16 @@ class StorageOptions(BaseModel):
     key: str | None = Field(default=None, description="Storage key")
 
 
+class HtmlOptions(BaseModel):
+    selector: str | None = Field(
+        default=None, description="A string containing a CSS selector"
+    )
+
+
 class ConvertRequest(BaseModel):
     llm: LlmOptions | None = Field(default=None, description="LLM options")
     storage: StorageOptions | None = Field(default=None, description="Storage options")
+    html: HtmlOptions | None = Field(default=None, description="HTML options")
     keep_data_uris: bool = Field(
         default=False,
         description="If keep_data_uris is True, use base64 encoding for images",

--- a/packages/markitdown/src/markitdown/converters/_html_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_html_converter.py
@@ -44,9 +44,20 @@ class HtmlConverter(DocumentConverter):
         stream_info: StreamInfo,
         **kwargs: Any,  # Options to pass to the converter
     ) -> DocumentConverterResult:
+        selector = kwargs.pop("selector", None)
         # Parse the stream
         encoding = "utf-8" if stream_info.charset is None else stream_info.charset
         soup = BeautifulSoup(file_stream, "html.parser", from_encoding=encoding)
+
+        title = None if soup.title is None else soup.title.string
+        if selector:
+            nodes = soup.select(selector)
+            if not nodes:
+                raise ValueError(f"No elements match selector: {selector}")
+            scoped = BeautifulSoup("", "html.parser")
+            for node in nodes:
+                scoped.append(node)
+            soup = scoped
 
         # Remove javascript and style blocks
         for script in soup(["script", "style"]):
@@ -67,11 +78,11 @@ class HtmlConverter(DocumentConverter):
 
         return DocumentConverterResult(
             markdown=webpage_text,
-            title=None if soup.title is None else soup.title.string,
+            title=title,
         )
 
     def convert_string(
-        self, html_content: str, *, url: Optional[str] = None, **kwargs
+        self, html_content: str, *, url: Optional[str] = None, **kwargs: Any
     ) -> DocumentConverterResult:
         """
         Non-standard convenience method to convert a string to markdown.


### PR DESCRIPTION
- Introduce `selector` parameter in HTML converter to extract specific elements
- Update API to accept CSS selector in convert request
- Enhance `convert_stream` function to use the provided selector
- Version bump to 0.2.8