### PR TITLE
feat(api): add converter options to exclude specific converters

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/__about__.py
+++ b/packages/markitdown-api/src/markitdown_api/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/packages/markitdown-api/src/markitdown_api/api_converter.py
+++ b/packages/markitdown-api/src/markitdown_api/api_converter.py
@@ -21,7 +21,7 @@ class ApiConverter:
     def __init__(self, request: ConvertRequest):
         self.metadata: StreamMetadata | None = None
         self.request = request
-        self.markitdown = build_markitdown(request.llm)
+        self.markitdown = build_markitdown(request)
 
     def convert(self) -> ConvertResponse:
         converted_result = self._internal_convert(

--- a/packages/markitdown-api/src/markitdown_api/api_types.py
+++ b/packages/markitdown-api/src/markitdown_api/api_types.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from pydantic import BaseModel, Field
 from starlette.responses import Response
 from markitdown._llm_utils import get_llm_prompt
@@ -23,10 +25,20 @@ class HtmlOptions(BaseModel):
     )
 
 
+class ConverterOptions(BaseModel):
+    exclude: List[str] = Field(
+        default=[],
+        description="List of converter types to exclude (e.g. ['PlainTextConverter', 'DocxConverter'])",
+    )
+
+
 class ConvertRequest(BaseModel):
     llm: LlmOptions | None = Field(default=None, description="LLM options")
     storage: StorageOptions | None = Field(default=None, description="Storage options")
     html: HtmlOptions | None = Field(default=None, description="HTML options")
+    converter: ConverterOptions | None = Field(
+        default=None, description="Converter options"
+    )
     keep_data_uris: bool = Field(
         default=False,
         description="If keep_data_uris is True, use base64 encoding for images",

--- a/packages/markitdown-api/src/markitdown_api/commons.py
+++ b/packages/markitdown-api/src/markitdown_api/commons.py
@@ -4,8 +4,7 @@ from typing import Optional
 from openai import OpenAI
 
 from markitdown import MarkItDown
-from markitdown.converters import PlainTextConverter
-from markitdown_api.api_types import LlmOptions
+from markitdown_api.api_types import LlmOptions, ConvertRequest
 
 
 def is_blank(s: str) -> bool:
@@ -18,7 +17,7 @@ def blank_then_none(s: str) -> str | None:
     return s
 
 
-def build_markitdown(llm_options: Optional[LlmOptions] = None) -> MarkItDown:
+def _build_markitdown(llm_options: Optional[LlmOptions] = None) -> MarkItDown:
     base_url = api_key = llm_client = llm_model = None
     if llm_options:
         base_url = blank_then_none(llm_options.open_ai_base_url)
@@ -37,5 +36,15 @@ def build_markitdown(llm_options: Optional[LlmOptions] = None) -> MarkItDown:
         llm_client=llm_client,
         llm_model=llm_model,
     )
-    markitdown.unregister_converter(PlainTextConverter)
+    return markitdown
+
+
+def build_markitdown(request: ConvertRequest) -> MarkItDown:
+    markitdown = _build_markitdown(request.llm)
+    converter_options = request.converter
+    if not converter_options:
+        return markitdown
+
+    for converter in converter_options.exclude:
+        markitdown.unregister_converter(converter)
     return markitdown

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -654,12 +654,18 @@ class MarkItDown:
             0, ConverterRegistration(converter=converter, priority=priority)
         )
 
-    def unregister_converter(self, converter_type: Type[DocumentConverter]):
-        """Unregister a converter."""
+    def unregister_converter(self, converter_type: Union[Type[DocumentConverter], str]):
+        """Unregister a converter by type or class name."""
         new_converters = []
         for cr in self._converters:
-            if not isinstance(cr.converter, converter_type):
-                new_converters.append(cr)
+            if isinstance(converter_type, str):
+                # String matching: compare with class name
+                if cr.converter.__class__.__name__ != converter_type:
+                    new_converters.append(cr)
+            else:
+                # Type matching
+                if not isinstance(cr.converter, converter_type):
+                    new_converters.append(cr)
         self._converters = new_converters
 
     def _get_stream_info_guesses(


### PR DESCRIPTION
- Introduce ConverterOptions in api_types.py to specify converters to exclude
- Update ConvertRequest to include ConverterOptions
- Modify build_markitdown function to use converter options from request
- Enhance unregister_converter method in MarkItDown class to support string input