### PR TITLE
feat(core): add mimetype support for converted documents

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/api_converter.py
+++ b/packages/markitdown-api/src/markitdown_api/api_converter.py
@@ -34,6 +34,8 @@ class ApiConverter:
             title=converted_result.title,
             markdown=markdown,
         )
+        if converted_result.mimetype:
+            result.mimetype = converted_result.mimetype
         storage_result = None
         if self.request.storage:
             storage_result = StoragerRegistrar().storage(

--- a/packages/markitdown-api/src/markitdown_api/api_types.py
+++ b/packages/markitdown-api/src/markitdown_api/api_types.py
@@ -48,8 +48,11 @@ class ConvertRequest(BaseModel):
         return self.llm.prompt if self.llm else ""
 
 
+TEXT_MARKDOWN_MIME_TYPE = "text/markdown"
+
+
 class MarkdownResponse(Response):
-    media_type = "text/markdown"
+    media_type = TEXT_MARKDOWN_MIME_TYPE
 
 
 class StreamMetadata(BaseModel):
@@ -63,6 +66,9 @@ class StreamMetadata(BaseModel):
 
 class ConvertResult(BaseModel):
     title: str | None = Field(default=None)
+    mimetype: str | None = Field(
+        default=TEXT_MARKDOWN_MIME_TYPE, description="Mime type of the converted data"
+    )
     markdown: str
 
 

--- a/packages/markitdown-api/src/markitdown_api/convert_file.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_file.py
@@ -40,11 +40,11 @@ class FileApiConverter(ApiConverter):
             mimetype=self.metadata.mimetype, filename=self.request.file.filename
         )
         with BufferedReader(self.request.file.file) as buffered_reader:
-            convert_result = self.markitdown.convert_stream(
+            result = self.markitdown.convert_stream(
                 buffered_reader, stream_info=stream_info, **kwargs
             )
             return ConvertResult(
-                title=convert_result.title, markdown=convert_result.markdown
+                title=result.title, markdown=result.markdown, mimetype=result.mimetype
             )
 
 

--- a/packages/markitdown-api/src/markitdown_api/convert_http.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_http.py
@@ -78,7 +78,9 @@ class HttpApiConverter(ApiConverter):
             data_size=data_size, mimetype=mimetype, last_modified=last_modified
         )
         result = self.markitdown.convert_response(response, **kwargs)
-        return ConvertResult(markdown=result.markdown, title=result.title)
+        return ConvertResult(
+            markdown=result.markdown, title=result.title, mimetype=result.mimetype
+        )
 
 
 router = APIRouter(prefix="/convert/http", tags=[TAG])

--- a/packages/markitdown-api/src/markitdown_api/convert_text.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_text.py
@@ -40,7 +40,9 @@ class TextApiConverter(ApiConverter):
             stream=binary_io, stream_info=stream_info, **kwargs
         )
 
-        return ConvertResult(markdown=result.markdown, title=result.title)
+        return ConvertResult(
+            markdown=result.markdown, title=result.title, mimetype=result.mimetype
+        )
 
 
 router = APIRouter(

--- a/packages/markitdown-api/src/markitdown_api/convert_uri.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_uri.py
@@ -33,7 +33,9 @@ class UriApiConverter(ApiConverter):
 
     def _internal_convert(self, **kwargs: Any) -> ConvertResult:
         result = self.markitdown.convert_uri(self.request.uri, **kwargs)
-        return ConvertResult(title=result.title, markdown=result.markdown)
+        return ConvertResult(
+            title=result.title, markdown=result.markdown, mimetype=result.mimetype
+        )
 
 
 router = APIRouter(prefix="/convert/uri", tags=[TAG])

--- a/packages/markitdown-api/src/markitdown_api/storages/oss_storager.py
+++ b/packages/markitdown-api/src/markitdown_api/storages/oss_storager.py
@@ -9,12 +9,13 @@ from markitdown_api.api_types import (
     ConvertResult,
     StorageOptions,
     StorageResult,
+    TEXT_MARKDOWN_MIME_TYPE,
 )
 from markitdown_api.storages.storager import Storager
 
 _utf8_charset = "utf-8"
 _put_object_headers: oss2.CaseInsensitiveDict = oss2.CaseInsensitiveDict(
-    {"Content-Type": f"text/markdown; charset={_utf8_charset}"}
+    {"Content-Type": f"{TEXT_MARKDOWN_MIME_TYPE}; charset={_utf8_charset}"}
 )
 
 
@@ -53,7 +54,13 @@ class OssStorager(Storager):
         result: ConvertResult,
         **kwargs: Any,
     ) -> StorageResult:
-        headers = _put_object_headers.copy()
+        mimetype = TEXT_MARKDOWN_MIME_TYPE
+        if result.mimetype:
+            mimetype = result.mimetype
+
+        headers = oss2.CaseInsensitiveDict(
+            {"Content-Type": f"{mimetype}; charset={_utf8_charset}"}
+        )
         if result.title:
             headers["x-oss-meta-title"] = result.title.encode(_utf8_charset)
         self.bucket.put_object(

--- a/packages/markitdown/src/markitdown/_base_converter.py
+++ b/packages/markitdown/src/markitdown/_base_converter.py
@@ -10,6 +10,7 @@ class DocumentConverterResult:
         markdown: str,
         *,
         title: Optional[str] = None,
+        mimetype: Optional[str] = None,
     ):
         """
         Initialize the DocumentConverterResult.
@@ -23,6 +24,7 @@ class DocumentConverterResult:
         """
         self.markdown = markdown
         self.title = title
+        self.mimetype = mimetype
 
     @property
     def text_content(self) -> str:

--- a/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
@@ -68,4 +68,6 @@ class PlainTextConverter(DocumentConverter):
         else:
             text_content = str(from_bytes(file_stream.read()).best())
 
-        return DocumentConverterResult(markdown=text_content)
+        return DocumentConverterResult(
+            markdown=text_content, mimetype=stream_info.mimetype
+        )


### PR DESCRIPTION
- Add mimetype parameter to DocumentConverterResult
- Update plain text converter to set mimetype
- Modify API converter to include mimetype in responses
- Add mimetype field to ConvertResult model
- Update file, HTTP, text, and URI converters to handle mimetype
- Adjust OSS storage to use correct mimetype for markdown content