### PR TITLE
feat(api): add information about failed conversion attempts

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/api_converter.py
+++ b/packages/markitdown-api/src/markitdown_api/api_converter.py
@@ -1,10 +1,13 @@
 from typing import Any
 
+from markitdown import DocumentConverterResult
 from markitdown_api.api_types import (
     ConvertRequest,
     ConvertResult,
     ConvertResponse,
     StreamMetadata,
+    FailedAttempt,
+    FailedAttempts,
 )
 from markitdown_api.commons import build_markitdown
 from markitdown_api.storages.storager_registrar import StoragerRegistrar
@@ -39,15 +42,24 @@ class ApiConverter:
         storage_result = None
         if self.request.storage:
             storage_result = StoragerRegistrar().storage(
-                self.request.storage, self.metadata, converted_result
+                self.request.storage, self.metadata, result
             )
             result.markdown = ""
-
+        failed_attempts = None
+        if converted_result.failed_attempts:
+            failed_attempts = [
+                FailedAttempt(
+                    converter=attempt.converter.__class__.__name__,
+                    error_msg=str(attempt.exc_info),
+                )
+                for attempt in converted_result.failed_attempts
+            ]
         return ConvertResponse(
             metadata=self.metadata,
             result=result,
             storage=storage_result,
+            failed=FailedAttempts(attempts=failed_attempts),
         )
 
-    def _internal_convert(self, **kwargs: Any) -> ConvertResult:
+    def _internal_convert(self, **kwargs: Any) -> DocumentConverterResult:
         raise NotImplementedError

--- a/packages/markitdown-api/src/markitdown_api/api_types.py
+++ b/packages/markitdown-api/src/markitdown_api/api_types.py
@@ -79,13 +79,28 @@ class StorageResult(BaseModel):
     key: str = Field(description="Storage key")
 
 
+class FailedAttempt(BaseModel):
+    converter: str = Field(description="Converter name")
+    error_msg: str = Field(description="Exception info")
+
+
+class FailedAttempts(BaseModel):
+    attempts: List[FailedAttempt] = Field(default=[], description="Failed attempts")
+
+
 class ConvertResponse(BaseModel):
     metadata: StreamMetadata | None = Field(
         default=None,
         description="Metadata of the data",
     )
     result: ConvertResult | None = Field(default=None, description="Converted result")
-    storage: StorageResult | None = Field(
+    storage: StorageResult | None = (
+        Field(
+            default=None,
+            description="Storage result",
+        ),
+    )
+    failed: FailedAttempts | None = Field(
         default=None,
-        description="Storage result",
+        description="Failed attempts",
     )

--- a/packages/markitdown-api/src/markitdown_api/convert_file.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_file.py
@@ -3,10 +3,9 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, UploadFile, File, Form
 
-from markitdown import StreamInfo
+from markitdown import StreamInfo, DocumentConverterResult
 from markitdown_api.api_converter import ApiConverter
 from markitdown_api.api_types import (
-    ConvertResult,
     LlmOptions,
     MarkdownResponse,
     ConvertRequest,
@@ -31,7 +30,7 @@ class FileApiConverter(ApiConverter):
     def __init__(self, request: ConvertFileRequest):
         super().__init__(request)
 
-    def _internal_convert(self, **kwargs: Any) -> ConvertResult:
+    def _internal_convert(self, **kwargs: Any) -> DocumentConverterResult:
         self.metadata = StreamMetadata(
             data_size=self.request.file.size,
             mimetype=_parse_mime_type_from_content_type(self.request.file.content_type),
@@ -40,11 +39,8 @@ class FileApiConverter(ApiConverter):
             mimetype=self.metadata.mimetype, filename=self.request.file.filename
         )
         with BufferedReader(self.request.file.file) as buffered_reader:
-            result = self.markitdown.convert_stream(
+            return self.markitdown.convert_stream(
                 buffered_reader, stream_info=stream_info, **kwargs
-            )
-            return ConvertResult(
-                title=result.title, markdown=result.markdown, mimetype=result.mimetype
             )
 
 

--- a/packages/markitdown-api/src/markitdown_api/convert_http.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_http.py
@@ -7,10 +7,10 @@ from fastapi import Body, APIRouter
 from pydantic import Field
 from requests.utils import CaseInsensitiveDict
 
+from markitdown import DocumentConverterResult
 from markitdown_api.api_converter import ApiConverter
 from markitdown_api.api_types import (
     ConvertRequest,
-    ConvertResult,
     MarkdownResponse,
     ConvertResponse,
     StreamMetadata,
@@ -65,7 +65,7 @@ class HttpApiConverter(ApiConverter):
     def __init__(self, request: ConvertHttpRequest):
         super().__init__(request)
 
-    def _internal_convert(self, **kwargs: Any) -> ConvertResult:
+    def _internal_convert(self, **kwargs: Any) -> DocumentConverterResult:
         response = requests.request(
             self.request.method.value, self.request.url, headers=self.request.headers
         )
@@ -77,10 +77,7 @@ class HttpApiConverter(ApiConverter):
         self.metadata = StreamMetadata(
             data_size=data_size, mimetype=mimetype, last_modified=last_modified
         )
-        result = self.markitdown.convert_response(response, **kwargs)
-        return ConvertResult(
-            markdown=result.markdown, title=result.title, mimetype=result.mimetype
-        )
+        return self.markitdown.convert_response(response, **kwargs)
 
 
 router = APIRouter(prefix="/convert/http", tags=[TAG])

--- a/packages/markitdown-api/src/markitdown_api/convert_text.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_text.py
@@ -4,11 +4,10 @@ from typing import Any
 from fastapi import APIRouter
 from pydantic import Field
 
-from markitdown import StreamInfo
+from markitdown import StreamInfo, DocumentConverterResult
 from markitdown_api.api_converter import ApiConverter
 from markitdown_api.api_types import (
     ConvertRequest,
-    ConvertResult,
     StreamMetadata,
     ConvertResponse,
 )
@@ -27,7 +26,7 @@ class TextApiConverter(ApiConverter):
     def __init__(self, request: ConvertTextRequest):
         super().__init__(request)
 
-    def _internal_convert(self, **kwargs: Any) -> ConvertResult:
+    def _internal_convert(self, **kwargs: Any) -> DocumentConverterResult:
         text_binary = self.request.text.encode("utf-8")
         self.metadata = StreamMetadata(
             mimetype=self.request.mimetype,
@@ -36,12 +35,8 @@ class TextApiConverter(ApiConverter):
         binary_io = BytesIO(text_binary)
 
         stream_info = StreamInfo(mimetype=self.request.mimetype)
-        result = self.markitdown.convert_stream(
+        return self.markitdown.convert_stream(
             stream=binary_io, stream_info=stream_info, **kwargs
-        )
-
-        return ConvertResult(
-            markdown=result.markdown, title=result.title, mimetype=result.mimetype
         )
 
 

--- a/packages/markitdown-api/src/markitdown_api/convert_uri.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_uri.py
@@ -3,10 +3,10 @@ from typing import Annotated, Any
 from fastapi import Query, Body, APIRouter
 from pydantic import Field
 
+from markitdown import DocumentConverterResult
 from markitdown_api.api_converter import ApiConverter
 from markitdown_api.api_types import (
     ConvertRequest,
-    ConvertResult,
     MarkdownResponse,
     ConvertResponse,
 )
@@ -31,11 +31,8 @@ class UriApiConverter(ApiConverter):
     def __init__(self, request: ConvertUriRequest):
         super().__init__(request)
 
-    def _internal_convert(self, **kwargs: Any) -> ConvertResult:
-        result = self.markitdown.convert_uri(self.request.uri, **kwargs)
-        return ConvertResult(
-            title=result.title, markdown=result.markdown, mimetype=result.mimetype
-        )
+    def _internal_convert(self, **kwargs: Any) -> DocumentConverterResult:
+        return self.markitdown.convert_uri(self.request.uri, **kwargs)
 
 
 router = APIRouter(prefix="/convert/uri", tags=[TAG])

--- a/packages/markitdown/src/markitdown/_base_converter.py
+++ b/packages/markitdown/src/markitdown/_base_converter.py
@@ -1,4 +1,6 @@
-from typing import Any, BinaryIO, Optional
+from typing import Any, BinaryIO, Optional, List
+
+from ._exceptions import FailedConversionAttempt
 from ._stream_info import StreamInfo
 
 
@@ -11,6 +13,7 @@ class DocumentConverterResult:
         *,
         title: Optional[str] = None,
         mimetype: Optional[str] = None,
+        failed_attempts: List[FailedConversionAttempt] = None,
     ):
         """
         Initialize the DocumentConverterResult.
@@ -25,6 +28,7 @@ class DocumentConverterResult:
         self.markdown = markdown
         self.title = title
         self.mimetype = mimetype
+        self.failed_attempts = failed_attempts
 
     @property
     def text_content(self) -> str:

--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -603,6 +603,7 @@ class MarkItDown:
                         [line.rstrip() for line in re.split(r"\r?\n", res.text_content)]
                     )
                     res.text_content = re.sub(r"\n{3,}", "\n\n", res.text_content)
+                    res.failed_attempts = failed_attempts
                     return res
 
         # If we got this far without success, report any exceptions


### PR DESCRIPTION
- Add `failed_attempts` attribute to `DocumentConverterResult`
- Propagate failed attempts through the conversion process
- Include failed attempts in the API response
- Update API models to accommodate new failure information