### PR TITLE
refactor(api): improve error handling and rename models

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/__about__.py
+++ b/packages/markitdown-api/src/markitdown_api/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/packages/markitdown-api/src/markitdown_api/api_converter.py
+++ b/packages/markitdown-api/src/markitdown_api/api_converter.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Any
 
 from markitdown import DocumentConverterResult

--- a/packages/markitdown-api/src/markitdown_api/api_converter.py
+++ b/packages/markitdown-api/src/markitdown_api/api_converter.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Any
 
 from markitdown import DocumentConverterResult
@@ -7,7 +8,7 @@ from markitdown_api.api_types import (
     ConvertResponse,
     StreamMetadata,
     FailedAttempt,
-    FailedAttempts,
+    FailedResult,
 )
 from markitdown_api.commons import build_markitdown
 from markitdown_api.storages.storager_registrar import StoragerRegistrar
@@ -27,7 +28,7 @@ class ApiConverter:
         self.markitdown = build_markitdown(request)
 
     def convert(self) -> ConvertResponse:
-        converted_result = self._internal_convert(
+        converted_result: DocumentConverterResult = self._internal_convert(
             llm_prompt=self.request.get_llm_prompt(),
             keep_data_uris=self.request.keep_data_uris,
             selector=self.request.html.selector if self.request.html else None,
@@ -47,18 +48,28 @@ class ApiConverter:
             result.markdown = ""
         failed_attempts = None
         if converted_result.failed_attempts:
-            failed_attempts = [
-                FailedAttempt(
-                    converter=attempt.converter.__class__.__name__,
-                    error_msg=str(attempt.exc_info),
+            failed_attempts = []
+            for attempt in converted_result.failed_attempts:
+                converter = type(attempt.converter).__name__
+                error_type = ""
+                error_msg = ""
+                if attempt.exc_info:
+                    error_type = attempt.exc_info[0].__name__
+                    error_msg = str(attempt.exc_info[1])
+                failed_attempts.append(
+                    FailedAttempt(
+                        converter=converter, error_type=error_type, error_msg=error_msg
+                    )
                 )
-                for attempt in converted_result.failed_attempts
-            ]
+
+        failed_result = None
+        if failed_attempts:
+            failed_result = FailedResult(attempts=failed_attempts)
         return ConvertResponse(
             metadata=self.metadata,
             result=result,
             storage=storage_result,
-            failed=FailedAttempts(attempts=failed_attempts),
+            failed=failed_result,
         )
 
     def _internal_convert(self, **kwargs: Any) -> DocumentConverterResult:

--- a/packages/markitdown-api/src/markitdown_api/api_types.py
+++ b/packages/markitdown-api/src/markitdown_api/api_types.py
@@ -81,10 +81,11 @@ class StorageResult(BaseModel):
 
 class FailedAttempt(BaseModel):
     converter: str = Field(description="Converter name")
+    error_type: str = Field(description="Exception type")
     error_msg: str = Field(description="Exception info")
 
 
-class FailedAttempts(BaseModel):
+class FailedResult(BaseModel):
     attempts: List[FailedAttempt] = Field(default=[], description="Failed attempts")
 
 
@@ -100,7 +101,7 @@ class ConvertResponse(BaseModel):
             description="Storage result",
         ),
     )
-    failed: FailedAttempts | None = Field(
+    failed: FailedResult | None = Field(
         default=None,
         description="Failed attempts",
     )


### PR DESCRIPTION
- Rename FailedAttempts to FailedResult for better clarity
- Add error_type to FailedAttempt for exception type information
- Update error handling in APIConverter to provide more detailed information
- Refactor failed result construction for better readability and efficiency