### PR TITLE
feat(api): add strict mode for markdown conversion

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/__about__.py
+++ b/packages/markitdown-api/src/markitdown_api/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "0.3.3"
+__version__ = "0.3.5"

--- a/packages/markitdown-api/src/markitdown_api/api_converter.py
+++ b/packages/markitdown-api/src/markitdown_api/api_converter.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from markitdown import DocumentConverterResult
+from markitdown import DocumentConverterResult, FileConversionException
 from markitdown_api.api_types import (
     ConvertRequest,
     ConvertResult,
@@ -8,6 +8,7 @@ from markitdown_api.api_types import (
     StreamMetadata,
     FailedAttempt,
     FailedResult,
+    TEXT_MARKDOWN_MIME_TYPE,
 )
 from markitdown_api.commons import build_markitdown
 from markitdown_api.storages.storager_registrar import StoragerRegistrar
@@ -39,6 +40,9 @@ class ApiConverter:
         )
         if converted_result.mimetype:
             result.mimetype = converted_result.mimetype
+
+        if self.request.strict and converted_result.mimetype != TEXT_MARKDOWN_MIME_TYPE:
+            raise FileConversionException(attempts=converted_result.failed_attempts)
         storage_result = None
         if self.request.storage:
             storage_result = StoragerRegistrar().storage(

--- a/packages/markitdown-api/src/markitdown_api/api_types.py
+++ b/packages/markitdown-api/src/markitdown_api/api_types.py
@@ -43,6 +43,10 @@ class ConvertRequest(BaseModel):
         default=False,
         description="If keep_data_uris is True, use base64 encoding for images",
     )
+    strict: bool = Field(
+        default=False,
+        description="If Strict is True, use strict mode to convert markdown",
+    )
 
     def get_llm_prompt(self) -> str:
         return self.llm.prompt if self.llm else ""

--- a/packages/markitdown-api/src/markitdown_api/app.py
+++ b/packages/markitdown-api/src/markitdown_api/app.py
@@ -3,6 +3,7 @@ from requests import HTTPError
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from markitdown import FileConversionException
 from markitdown.__about__ import __version__ as markitdown_version
 from markitdown_api import (
     convert_uri,
@@ -30,22 +31,26 @@ app.include_router(convert_file.router)
 app.include_router(convert_http.router)
 
 
+def __error_content(exc: Exception):
+    return {"detail": str(exc)}
+
+
 async def file_not_found_handler(request: Request, exc: FileNotFoundError):
-    return JSONResponse(status_code=404, content={"detail": str(exc)})
+    return JSONResponse(status_code=404, content=__error_content(exc))
 
 
 async def value_error_handler(request: Request, exc: ValueError):
-    return JSONResponse(status_code=400, content={"detail": str(exc)})
+    return JSONResponse(status_code=400, content=__error_content(exc))
 
 
 async def http_error_handler(request: Request, exc: HTTPError):
     return JSONResponse(
-        status_code=exc.response.status_code, content={"detail": str(exc)}
+        status_code=exc.response.status_code, content=__error_content(exc)
     )
 
 
 async def type_error_handler(request: Request, exc: TypeError):
-    return JSONResponse(status_code=400, content={"detail": str(exc)})
+    return JSONResponse(status_code=400, content=__error_content(exc))
 
 
 async def key_error_handler(request: Request, exc: KeyError):
@@ -54,12 +59,16 @@ async def key_error_handler(request: Request, exc: KeyError):
     )
 
 
+async def file_conversion_handler(request: Request, exc: FileConversionException):
+    return JSONResponse(status_code=400, content=__error_content(exc))
+
+
 async def index_error_handler(request: Request, exc: IndexError):
-    return JSONResponse(status_code=400, content={"detail": str(exc)})
+    return JSONResponse(status_code=400, content=__error_content(exc))
 
 
 async def global_exception_handler(request: Request, exc: Exception):
-    return JSONResponse(status_code=500, content={"detail": str(exc)})
+    return JSONResponse(status_code=500, content=__error_content(exc))
 
 
 app.add_exception_handler(FileNotFoundError, file_not_found_handler)
@@ -68,4 +77,5 @@ app.add_exception_handler(HTTPError, http_error_handler)
 app.add_exception_handler(TypeError, type_error_handler)
 app.add_exception_handler(KeyError, key_error_handler)
 app.add_exception_handler(IndexError, index_error_handler)
+app.add_exception_handler(FileConversionException, file_conversion_handler)
 app.add_exception_handler(Exception, global_exception_handler)


### PR DESCRIPTION
- Add strict parameter to ConvertRequest to enable strict markdown conversion
- Implement FileConversionException to handle conversion errors in strict mode
- Update API to return appropriate error response when strict mode conversion fails