### PR TITLE
refactor(api): rename markdown conversion functions for clarity

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/convert_http.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_http.py
@@ -60,7 +60,7 @@ async def convert_http(
 
 
 @router.post(path="/markdown", response_class=MarkdownResponse)
-async def convert_uri_markdown(
+async def convert_http_markdown(
     request: Annotated[
         ConvertHttpRequest, Body(examples=[{"url": "https://wow.ahoo.me/"}])
     ]

--- a/packages/markitdown-api/src/markitdown_api/convert_text.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_text.py
@@ -55,5 +55,5 @@ async def convert_text(request: ConvertTextRequest):
 
 
 @router.post(path="/markdown", response_class=MarkdownResponse)
-async def convert_uri_markdown(request: ConvertTextRequest):
+async def convert_text_markdown(request: ConvertTextRequest):
     return TextApiConverter(request).convert().result.markdown


### PR DESCRIPTION
- Rename convert_uri_markdown to convert_http_markdown in convert_http.py
- Rename convert_uri_markdown to convert_text_markdown in convert_text.py