### PR TITLE
feat(api): upload converted images to OSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 src/.DS_Store
 .DS_Store
 .cursorrules

--- a/packages/markitdown-api/pyproject.toml
+++ b/packages/markitdown-api/pyproject.toml
@@ -10,7 +10,7 @@ name = "markitdown-api"
 dynamic = ["version"]
 description = ''
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = "MIT"
 keywords = []
 authors = [
@@ -19,11 +19,10 @@ authors = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/packages/markitdown-api/src/markitdown_api/api_converter.py
+++ b/packages/markitdown-api/src/markitdown_api/api_converter.py
@@ -38,7 +38,9 @@ class ApiConverter:
         markdown = remove_all_zw_chars(converted_result.markdown)
         markdown = replace_data_images_with_oss_urls(markdown)
         if self.request.rag.enabled:
-            markdown = optimize_markdown_for_rag(markdown)
+            markdown = optimize_markdown_for_rag(
+                markdown, heading_keywords=self.request.rag.heading_keywords
+            )
         result = ConvertResult(
             title=converted_result.title,
             markdown=markdown,

--- a/packages/markitdown-api/src/markitdown_api/api_converter.py
+++ b/packages/markitdown-api/src/markitdown_api/api_converter.py
@@ -12,6 +12,7 @@ from markitdown_api.api_types import (
 )
 from markitdown_api.commons import build_markitdown
 from markitdown_api.oss_image_upload import replace_data_images_with_oss_urls
+from markitdown_api.rag_markdown import optimize_markdown_for_rag
 from markitdown_api.storages.storager_registrar import StoragerRegistrar
 
 
@@ -36,6 +37,8 @@ class ApiConverter:
         )
         markdown = remove_all_zw_chars(converted_result.markdown)
         markdown = replace_data_images_with_oss_urls(markdown)
+        if self.request.rag and self.request.rag.enabled:
+            markdown = optimize_markdown_for_rag(markdown)
         result = ConvertResult(
             title=converted_result.title,
             markdown=markdown,

--- a/packages/markitdown-api/src/markitdown_api/api_converter.py
+++ b/packages/markitdown-api/src/markitdown_api/api_converter.py
@@ -11,6 +11,7 @@ from markitdown_api.api_types import (
     TEXT_MARKDOWN_MIME_TYPE,
 )
 from markitdown_api.commons import build_markitdown
+from markitdown_api.oss_image_upload import replace_data_images_with_oss_urls
 from markitdown_api.storages.storager_registrar import StoragerRegistrar
 
 
@@ -34,6 +35,7 @@ class ApiConverter:
             selector=self.request.html.selector if self.request.html else None,
         )
         markdown = remove_all_zw_chars(converted_result.markdown)
+        markdown = replace_data_images_with_oss_urls(markdown)
         result = ConvertResult(
             title=converted_result.title,
             markdown=markdown,

--- a/packages/markitdown-api/src/markitdown_api/api_converter.py
+++ b/packages/markitdown-api/src/markitdown_api/api_converter.py
@@ -37,7 +37,7 @@ class ApiConverter:
         )
         markdown = remove_all_zw_chars(converted_result.markdown)
         markdown = replace_data_images_with_oss_urls(markdown)
-        if self.request.rag and self.request.rag.enabled:
+        if self.request.rag.enabled:
             markdown = optimize_markdown_for_rag(markdown)
         result = ConvertResult(
             title=converted_result.title,

--- a/packages/markitdown-api/src/markitdown_api/api_types.py
+++ b/packages/markitdown-api/src/markitdown_api/api_types.py
@@ -40,7 +40,7 @@ class ConvertRequest(BaseModel):
         default=None, description="Converter options"
     )
     keep_data_uris: bool = Field(
-        default=False,
+        default=True,
         description="If keep_data_uris is True, use base64 encoding for images",
     )
     strict: bool = Field(

--- a/packages/markitdown-api/src/markitdown_api/api_types.py
+++ b/packages/markitdown-api/src/markitdown_api/api_types.py
@@ -37,6 +37,10 @@ class RagOptions(BaseModel):
         default=True,
         description="If enabled, lightly normalize Markdown for RAG chunking",
     )
+    heading_keywords: List[str] = Field(
+        default_factory=list,
+        description="Optional exact headings to promote during RAG cleanup",
+    )
 
 
 class ConvertRequest(BaseModel):

--- a/packages/markitdown-api/src/markitdown_api/api_types.py
+++ b/packages/markitdown-api/src/markitdown_api/api_types.py
@@ -32,6 +32,13 @@ class ConverterOptions(BaseModel):
     )
 
 
+class RagOptions(BaseModel):
+    enabled: bool = Field(
+        default=False,
+        description="If enabled, lightly normalize Markdown for RAG chunking",
+    )
+
+
 class ConvertRequest(BaseModel):
     llm: LlmOptions | None = Field(default=None, description="LLM options")
     storage: StorageOptions | None = Field(default=None, description="Storage options")
@@ -39,6 +46,7 @@ class ConvertRequest(BaseModel):
     converter: ConverterOptions | None = Field(
         default=None, description="Converter options"
     )
+    rag: RagOptions | None = Field(default=None, description="RAG options")
     keep_data_uris: bool = Field(
         default=True,
         description="If keep_data_uris is True, use base64 encoding for images",

--- a/packages/markitdown-api/src/markitdown_api/api_types.py
+++ b/packages/markitdown-api/src/markitdown_api/api_types.py
@@ -34,7 +34,7 @@ class ConverterOptions(BaseModel):
 
 class RagOptions(BaseModel):
     enabled: bool = Field(
-        default=False,
+        default=True,
         description="If enabled, lightly normalize Markdown for RAG chunking",
     )
 
@@ -46,7 +46,7 @@ class ConvertRequest(BaseModel):
     converter: ConverterOptions | None = Field(
         default=None, description="Converter options"
     )
-    rag: RagOptions | None = Field(default=None, description="RAG options")
+    rag: RagOptions = Field(default_factory=RagOptions, description="RAG options")
     keep_data_uris: bool = Field(
         default=True,
         description="If keep_data_uris is True, use base64 encoding for images",

--- a/packages/markitdown-api/src/markitdown_api/convert_file.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_file.py
@@ -53,7 +53,7 @@ async def convert_file(
     openai_api_key: Annotated[str, Form()] = "",
     llm_model: Annotated[str, Form()] = "",
     llm_prompt: Annotated[str, Form()] = "",
-    keep_data_uris: Annotated[bool, Form()] = False,
+    keep_data_uris: Annotated[bool, Form()] = True,
 ):
     return FileApiConverter(
         ConvertFileRequest(
@@ -76,7 +76,7 @@ async def convert_file_markdown(
     openai_api_key: Annotated[str, Form()] = "",
     llm_model: Annotated[str, Form()] = "",
     llm_prompt: Annotated[str, Form()] = "",
-    keep_data_uris: Annotated[bool, Form()] = False,
+    keep_data_uris: Annotated[bool, Form()] = True,
 ):
     return (
         FileApiConverter(

--- a/packages/markitdown-api/src/markitdown_api/convert_file.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_file.py
@@ -47,6 +47,11 @@ class FileApiConverter(ApiConverter):
             )
 
 
+def _parse_rag_heading_keywords(value: str) -> list[str]:
+    normalized = value.replace("，", ",").replace("\n", ",")
+    return [keyword.strip() for keyword in normalized.split(",") if keyword.strip()]
+
+
 @router.post(path="", response_model=ConvertResponse)
 async def convert_file(
     file: Annotated[UploadFile, File()],
@@ -56,12 +61,16 @@ async def convert_file(
     llm_prompt: Annotated[str, Form()] = "",
     keep_data_uris: Annotated[bool, Form()] = True,
     rag_clean: Annotated[bool, Form()] = True,
+    rag_heading_keywords: Annotated[str, Form()] = "",
 ):
     return FileApiConverter(
         ConvertFileRequest(
             file=file,
             keep_data_uris=keep_data_uris,
-            rag=RagOptions(enabled=rag_clean),
+            rag=RagOptions(
+                enabled=rag_clean,
+                heading_keywords=_parse_rag_heading_keywords(rag_heading_keywords),
+            ),
             llm=LlmOptions(
                 model=llm_model,
                 open_ai_api_key=openai_api_key,
@@ -81,13 +90,17 @@ async def convert_file_markdown(
     llm_prompt: Annotated[str, Form()] = "",
     keep_data_uris: Annotated[bool, Form()] = True,
     rag_clean: Annotated[bool, Form()] = True,
+    rag_heading_keywords: Annotated[str, Form()] = "",
 ):
     return (
         FileApiConverter(
             ConvertFileRequest(
                 file=file,
                 keep_data_uris=keep_data_uris,
-                rag=RagOptions(enabled=rag_clean),
+                rag=RagOptions(
+                    enabled=rag_clean,
+                    heading_keywords=_parse_rag_heading_keywords(rag_heading_keywords),
+                ),
                 llm=LlmOptions(
                     model=llm_model,
                     open_ai_api_key=openai_api_key,

--- a/packages/markitdown-api/src/markitdown_api/convert_file.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_file.py
@@ -11,6 +11,7 @@ from markitdown_api.api_types import (
     MarkdownResponse,
     ConvertRequest,
     ConvertResponse,
+    RagOptions,
     StreamMetadata,
 )
 
@@ -54,11 +55,13 @@ async def convert_file(
     llm_model: Annotated[str, Form()] = "",
     llm_prompt: Annotated[str, Form()] = "",
     keep_data_uris: Annotated[bool, Form()] = True,
+    rag_clean: Annotated[bool, Form()] = False,
 ):
     return FileApiConverter(
         ConvertFileRequest(
             file=file,
             keep_data_uris=keep_data_uris,
+            rag=RagOptions(enabled=rag_clean),
             llm=LlmOptions(
                 model=llm_model,
                 open_ai_api_key=openai_api_key,
@@ -77,12 +80,14 @@ async def convert_file_markdown(
     llm_model: Annotated[str, Form()] = "",
     llm_prompt: Annotated[str, Form()] = "",
     keep_data_uris: Annotated[bool, Form()] = True,
+    rag_clean: Annotated[bool, Form()] = False,
 ):
     return (
         FileApiConverter(
             ConvertFileRequest(
                 file=file,
                 keep_data_uris=keep_data_uris,
+                rag=RagOptions(enabled=rag_clean),
                 llm=LlmOptions(
                     model=llm_model,
                     open_ai_api_key=openai_api_key,

--- a/packages/markitdown-api/src/markitdown_api/convert_file.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_file.py
@@ -55,7 +55,7 @@ async def convert_file(
     llm_model: Annotated[str, Form()] = "",
     llm_prompt: Annotated[str, Form()] = "",
     keep_data_uris: Annotated[bool, Form()] = True,
-    rag_clean: Annotated[bool, Form()] = False,
+    rag_clean: Annotated[bool, Form()] = True,
 ):
     return FileApiConverter(
         ConvertFileRequest(
@@ -80,7 +80,7 @@ async def convert_file_markdown(
     llm_model: Annotated[str, Form()] = "",
     llm_prompt: Annotated[str, Form()] = "",
     keep_data_uris: Annotated[bool, Form()] = True,
-    rag_clean: Annotated[bool, Form()] = False,
+    rag_clean: Annotated[bool, Form()] = True,
 ):
     return (
         FileApiConverter(

--- a/packages/markitdown-api/src/markitdown_api/oss_image_upload.py
+++ b/packages/markitdown-api/src/markitdown_api/oss_image_upload.py
@@ -1,0 +1,187 @@
+import base64
+import hashlib
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from typing import Callable, Protocol
+from urllib.parse import quote, urlparse, urlunparse
+
+logger = logging.getLogger(__name__)
+
+_DATA_IMAGE_RE = re.compile(
+    r"!\[(?P<alt>(?:\\.|[^\]])*)\]"
+    r"\("
+    r"(?P<uri>data:(?P<mimetype>image/[A-Za-z0-9.+-]+);base64,(?P<payload>[A-Za-z0-9+/=\r\n]+))"
+    r"(?P<title>\s+\"(?:\\.|[^\"])*\")?"
+    r"\)"
+)
+
+_IMAGE_EXTENSIONS = {
+    "image/bmp": "bmp",
+    "image/gif": "gif",
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/png": "png",
+    "image/svg+xml": "svg",
+    "image/webp": "webp",
+}
+
+
+def _credentials_provider_from_environment(credentials_module):
+    access_key_id = os.environ.get("OSS_ACCESS_KEY_ID")
+    access_key_secret = os.environ.get("OSS_ACCESS_KEY_SECRET") or os.environ.get(
+        "OSS_SECRET_ACCESS_KEY"
+    )
+    security_token = os.environ.get("OSS_SESSION_TOKEN")
+
+    if not access_key_id:
+        raise ValueError("OSS_ACCESS_KEY_ID is not set")
+    if not access_key_secret:
+        raise ValueError("OSS_ACCESS_KEY_SECRET is not set")
+
+    return credentials_module.StaticCredentialsProvider(
+        access_key_id,
+        access_key_secret,
+        security_token,
+    )
+
+
+class ImageUploader(Protocol):
+    def upload_image(self, mimetype: str, content: bytes) -> str:
+        """Upload an image and return its public URL."""
+
+
+class OssImageUploader:
+    def __init__(
+        self,
+        *,
+        bucket=None,
+        endpoint: str | None = None,
+        bucket_name: str | None = None,
+        key_prefix: str | None = None,
+        public_base_url: str | None = None,
+        object_acl: str | None = None,
+        now: Callable[[], datetime] | None = None,
+    ):
+        self.endpoint = endpoint or os.environ.get("OSS_ENDPOINT")
+        if self.endpoint is None:
+            raise ValueError("OSS_ENDPOINT is not set")
+
+        self.bucket_name = bucket_name or os.environ.get("OSS_BUCKET")
+        if self.bucket_name is None:
+            raise ValueError("OSS_BUCKET is not set")
+
+        self.key_prefix = (
+            key_prefix or os.environ.get("OSS_IMAGE_KEY_PREFIX") or "images"
+        ).strip("/")
+        self._public_base_url = (
+            public_base_url or os.environ.get("OSS_PUBLIC_BASE_URL") or ""
+        ).rstrip("/")
+        self.object_acl = (
+            object_acl or os.environ.get("OSS_OBJECT_ACL") or "public-read"
+        )
+        self._now = now or (lambda: datetime.now(timezone.utc))
+
+        if bucket is None:
+            import oss2
+
+            oss_region_key = "OSS_REGION"
+            region = os.environ.get(oss_region_key)
+            if region is None:
+                raise ValueError(f"{oss_region_key} is not set")
+
+            credentials_provider = _credentials_provider_from_environment(
+                oss2.credentials
+            )
+            auth = oss2.ProviderAuthV4(credentials_provider)
+            bucket = oss2.Bucket(
+                auth,
+                self.endpoint,
+                self.bucket_name,
+                region=region,
+            )
+
+        self.bucket = bucket
+
+    def upload_image(self, mimetype: str, content: bytes) -> str:
+        extension = self._extension_for_mimetype(mimetype)
+        now = self._now().astimezone(timezone.utc)
+        digest = hashlib.sha256(content).hexdigest()
+        key_parts = [
+            self.key_prefix,
+            f"{now:%Y}",
+            f"{now:%m}",
+            f"{now:%d}",
+            f"{digest}.{extension}",
+        ]
+        key = "/".join(part for part in key_parts if part)
+        self.bucket.put_object(
+            key,
+            content,
+            headers={
+                "Content-Type": mimetype,
+                "x-oss-object-acl": self.object_acl,
+            },
+        )
+        return self._object_url(key)
+
+    def _extension_for_mimetype(self, mimetype: str) -> str:
+        extension = _IMAGE_EXTENSIONS.get(mimetype.lower())
+        if extension is None:
+            raise ValueError(f"Unsupported image mimetype: {mimetype}")
+        return extension
+
+    def _object_url(self, key: str) -> str:
+        if self._public_base_url:
+            return f"{self._public_base_url}/{quote(key, safe='/')}"
+
+        endpoint = self.endpoint.rstrip("/")
+        if "://" not in endpoint:
+            endpoint = f"https://{endpoint}"
+
+        parsed = urlparse(endpoint)
+        host = parsed.netloc
+        if not host.startswith(f"{self.bucket_name}."):
+            host = f"{self.bucket_name}.{host}"
+
+        path = parsed.path.rstrip("/")
+        object_path = (
+            f"{path}/{quote(key, safe='/')}" if path else f"/{quote(key, safe='/')}"
+        )
+        return urlunparse((parsed.scheme, host, object_path, "", "", ""))
+
+
+def replace_data_images_with_oss_urls(
+    markdown: str,
+    *,
+    uploader_factory: Callable[[], ImageUploader] = OssImageUploader,
+) -> str:
+    if "data:image/" not in markdown:
+        return markdown
+
+    try:
+        uploader = uploader_factory()
+    except Exception as exc:
+        logger.warning(
+            "OSS image uploader is unavailable; keeping data URI images: %s", exc
+        )
+        return markdown
+
+    def replace(match: re.Match) -> str:
+        mimetype = match.group("mimetype")
+        payload = "".join(match.group("payload").split())
+        try:
+            content = base64.b64decode(payload, validate=True)
+            url = uploader.upload_image(mimetype, content)
+        except Exception as exc:
+            logger.warning(
+                "Failed to upload embedded image to OSS; keeping data URI: %s",
+                exc,
+            )
+            return match.group(0)
+
+        title = match.group("title") or ""
+        return f"![{match.group('alt')}]({url}{title})"
+
+    return _DATA_IMAGE_RE.sub(replace, markdown)

--- a/packages/markitdown-api/src/markitdown_api/oss_image_upload.py
+++ b/packages/markitdown-api/src/markitdown_api/oss_image_upload.py
@@ -120,6 +120,7 @@ class OssImageUploader:
             key,
             content,
             headers={
+                "Content-Disposition": "inline",
                 "Content-Type": mimetype,
                 "x-oss-object-acl": self.object_acl,
             },

--- a/packages/markitdown-api/src/markitdown_api/oss_image_upload.py
+++ b/packages/markitdown-api/src/markitdown_api/oss_image_upload.py
@@ -38,7 +38,7 @@ def _credentials_provider_from_environment(credentials_module):
     if not access_key_id:
         raise ValueError("OSS_ACCESS_KEY_ID is not set")
     if not access_key_secret:
-        raise ValueError("OSS_ACCESS_KEY_SECRET is not set")
+        raise ValueError("OSS_ACCESS_KEY_SECRET or OSS_SECRET_ACCESS_KEY is not set")
 
     return credentials_module.StaticCredentialsProvider(
         access_key_id,
@@ -164,7 +164,7 @@ def replace_data_images_with_oss_urls(
     try:
         uploader = uploader_factory()
     except Exception as exc:
-        logger.warning(
+        logger.info(
             "OSS image uploader is unavailable; keeping data URI images: %s", exc
         )
         return markdown

--- a/packages/markitdown-api/src/markitdown_api/rag_markdown.py
+++ b/packages/markitdown-api/src/markitdown_api/rag_markdown.py
@@ -1,0 +1,175 @@
+import re
+from collections import Counter
+
+_MARKDOWN_IMAGE_RE = re.compile(
+    r"^!\[(?P<alt>(?:\\.|[^\]])*)\]" r"\(" r"(?P<target>[^)]*)" r"\)$"
+)
+
+_EXACT_SECTION_HEADINGS = {
+    "目录",
+    "安全服务",
+    "工业安全解决方案",
+    "定制化产品",
+    "工业通讯",
+    "工业电子",
+    "现场电源分配",
+    "快速连接系统",
+    "联系我们",
+}
+
+_NOISE_LINES = {"+", "-", "--", "是", "否", "×", "√"}
+
+
+def optimize_markdown_for_rag(markdown: str) -> str:
+    """Lightly normalize converted Markdown so downstream chunking has anchors."""
+
+    lines = _merge_split_registered_terms(markdown.splitlines())
+    line_counts = Counter(
+        line.strip()
+        for line in lines
+        if _is_context_line(line.strip()) and not _is_standalone_page_number(line)
+    )
+
+    output: list[str] = []
+    current_context: str | None = None
+    title_seen = False
+
+    for raw_line in lines:
+        line = raw_line.strip()
+
+        if not line:
+            if output and output[-1] != "":
+                output.append("")
+            continue
+
+        if _is_standalone_page_number(line):
+            continue
+
+        if line in _NOISE_LINES:
+            continue
+
+        image_match = _MARKDOWN_IMAGE_RE.match(line)
+        if image_match:
+            output.append(_enrich_image_alt(image_match, current_context))
+            continue
+
+        if _is_table_line(line):
+            output.append(line)
+            continue
+
+        if not title_seen:
+            title_seen = True
+            if line.startswith("#"):
+                output.append(line)
+            else:
+                output.append(f"# {line}")
+            current_context = _plain_heading_text(output[-1])
+            continue
+
+        if _is_likely_section_heading(line, line_counts):
+            heading = line if line.startswith("#") else f"## {line}"
+            output.append(heading)
+            current_context = _plain_heading_text(heading)
+            continue
+
+        if _is_context_line(line):
+            current_context = line
+        output.append(line)
+
+    while output and output[-1] == "":
+        output.pop()
+
+    return "\n".join(output)
+
+
+def _merge_split_registered_terms(lines: list[str]) -> list[str]:
+    merged: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.strip() == "®" and i + 1 < len(lines):
+            blank_buffer = _pop_trailing_blank_lines(merged)
+            suffix = lines[i + 1].strip()
+            if merged and 1 <= len(suffix) <= 12:
+                previous = merged.pop().rstrip()
+                merged.append(f"{previous}® {suffix}")
+                i += 2
+                continue
+            merged.extend(blank_buffer)
+
+        if line.strip().startswith("®"):
+            blank_buffer = _pop_trailing_blank_lines(merged)
+            if merged:
+                previous = merged.pop().rstrip()
+                merged.append(f"{previous}{line.strip()}")
+                i += 1
+                continue
+            merged.extend(blank_buffer)
+
+        merged.append(line)
+        i += 1
+    return merged
+
+
+def _pop_trailing_blank_lines(lines: list[str]) -> list[str]:
+    blanks: list[str] = []
+    while lines and not lines[-1].strip():
+        blanks.insert(0, lines.pop())
+    return blanks
+
+
+def _enrich_image_alt(match: re.Match, current_context: str | None) -> str:
+    alt = match.group("alt")
+    target = match.group("target")
+    if current_context and alt.startswith("PDF page ") and current_context not in alt:
+        alt = f"{_escape_alt_text(current_context)} - {alt}"
+    return f"![{alt}]({target})"
+
+
+def _escape_alt_text(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("]", "\\]")
+
+
+def _is_standalone_page_number(line: str) -> bool:
+    stripped = line.strip()
+    return stripped.isdigit() and 1 <= len(stripped) <= 3
+
+
+def _is_table_line(line: str) -> bool:
+    return "|" in line
+
+
+def _is_context_line(line: str) -> bool:
+    if not line or line.startswith("#"):
+        return False
+    if line in _NOISE_LINES or len(line) <= 1:
+        return False
+    if _is_table_line(line) or _MARKDOWN_IMAGE_RE.match(line):
+        return False
+    if _is_standalone_page_number(line):
+        return False
+    if re.match(r"^\d+[\.)]\s+", line):
+        return False
+    if any(mark in line for mark in "，。！？；：,.!?;:"):
+        return False
+    return len(line) <= 36
+
+
+def _is_likely_section_heading(line: str, line_counts: Counter[str]) -> bool:
+    if line.startswith("#"):
+        return True
+    if not _is_context_line(line):
+        return False
+    if line in _EXACT_SECTION_HEADINGS:
+        return True
+    if "解决方案" in line and len(line) <= 24:
+        return True
+    return line_counts[line] >= 3 and _contains_cjk(line)
+
+
+def _contains_cjk(text: str) -> bool:
+    return bool(re.search(r"[\u3400-\u9fff]", text))
+
+
+def _plain_heading_text(line: str) -> str:
+    return line.lstrip("#").strip()

--- a/packages/markitdown-api/src/markitdown_api/rag_markdown.py
+++ b/packages/markitdown-api/src/markitdown_api/rag_markdown.py
@@ -6,26 +6,19 @@ _MARKDOWN_IMAGE_RE = re.compile(
 )
 _FENCE_RE = re.compile(r"^ {0,3}(?P<marker>`{3,}|~{3,})")
 
-_EXACT_SECTION_HEADINGS = {
-    "目录",
-    "安全服务",
-    "工业安全解决方案",
-    "定制化产品",
-    "工业通讯",
-    "工业电子",
-    "现场电源分配",
-    "快速连接系统",
-    "联系我们",
-}
-
 _NOISE_LINES = {"+", "-", "--", "是", "否", "×", "√"}
 
 
-def optimize_markdown_for_rag(markdown: str) -> str:
+def optimize_markdown_for_rag(
+    markdown: str, *, heading_keywords: list[str] | None = None
+) -> str:
     """Lightly normalize converted Markdown so downstream chunking has anchors."""
 
     lines = _merge_split_registered_terms(markdown.splitlines())
     line_counts = Counter(line.strip() for line in _non_fenced_lines(lines))
+    heading_keyword_set = {
+        keyword.strip() for keyword in (heading_keywords or []) if keyword.strip()
+    }
 
     output: list[str] = []
     current_context: str | None = None
@@ -75,7 +68,7 @@ def optimize_markdown_for_rag(markdown: str) -> str:
             current_context = _plain_heading_text(output[-1])
             continue
 
-        if _is_likely_section_heading(line, line_counts):
+        if _is_likely_section_heading(line, line_counts, heading_keyword_set):
             heading = line if line.startswith("#") else f"## {line}"
             output.append(heading)
             current_context = _plain_heading_text(heading)
@@ -201,14 +194,14 @@ def _is_context_line(line: str) -> bool:
     return len(line) <= 36
 
 
-def _is_likely_section_heading(line: str, line_counts: Counter[str]) -> bool:
+def _is_likely_section_heading(
+    line: str, line_counts: Counter[str], heading_keywords: set[str]
+) -> bool:
     if line.startswith("#"):
         return True
     if not _is_context_line(line):
         return False
-    if line in _EXACT_SECTION_HEADINGS:
-        return True
-    if "解决方案" in line and len(line) <= 24:
+    if line in heading_keywords:
         return True
     return line_counts[line] >= 3 and _contains_cjk(line)
 

--- a/packages/markitdown-api/src/markitdown_api/rag_markdown.py
+++ b/packages/markitdown-api/src/markitdown_api/rag_markdown.py
@@ -4,6 +4,7 @@ from collections import Counter
 _MARKDOWN_IMAGE_RE = re.compile(
     r"^!\[(?P<alt>(?:\\.|[^\]])*)\]" r"\(" r"(?P<target>[^)]*)" r"\)$"
 )
+_FENCE_RE = re.compile(r"^ {0,3}(?P<marker>`{3,}|~{3,})")
 
 _EXACT_SECTION_HEADINGS = {
     "目录",
@@ -24,17 +25,25 @@ def optimize_markdown_for_rag(markdown: str) -> str:
     """Lightly normalize converted Markdown so downstream chunking has anchors."""
 
     lines = _merge_split_registered_terms(markdown.splitlines())
-    line_counts = Counter(
-        line.strip()
-        for line in lines
-        if _is_context_line(line.strip()) and not _is_standalone_page_number(line)
-    )
+    line_counts = Counter(line.strip() for line in _non_fenced_lines(lines))
 
     output: list[str] = []
     current_context: str | None = None
     title_seen = False
+    fence_marker: str | None = None
 
     for raw_line in lines:
+        marker = _fence_marker(raw_line)
+        if fence_marker:
+            output.append(raw_line)
+            if marker == fence_marker:
+                fence_marker = None
+            continue
+        if marker:
+            output.append(raw_line)
+            fence_marker = marker
+            continue
+
         line = raw_line.strip()
 
         if not line:
@@ -84,9 +93,23 @@ def optimize_markdown_for_rag(markdown: str) -> str:
 
 def _merge_split_registered_terms(lines: list[str]) -> list[str]:
     merged: list[str] = []
+    fence_marker: str | None = None
     i = 0
     while i < len(lines):
         line = lines[i]
+        marker = _fence_marker(line)
+        if fence_marker:
+            merged.append(line)
+            if marker == fence_marker:
+                fence_marker = None
+            i += 1
+            continue
+        if marker:
+            merged.append(line)
+            fence_marker = marker
+            i += 1
+            continue
+
         if line.strip() == "®" and i + 1 < len(lines):
             blank_buffer = _pop_trailing_blank_lines(merged)
             suffix = lines[i + 1].strip()
@@ -109,6 +132,29 @@ def _merge_split_registered_terms(lines: list[str]) -> list[str]:
         merged.append(line)
         i += 1
     return merged
+
+
+def _non_fenced_lines(lines: list[str]):
+    fence_marker: str | None = None
+    for line in lines:
+        marker = _fence_marker(line)
+        if fence_marker:
+            if marker == fence_marker:
+                fence_marker = None
+            continue
+        if marker:
+            fence_marker = marker
+            continue
+        stripped = line.strip()
+        if _is_context_line(stripped) and not _is_standalone_page_number(stripped):
+            yield line
+
+
+def _fence_marker(line: str) -> str | None:
+    match = _FENCE_RE.match(line)
+    if not match:
+        return None
+    return match.group("marker")[0]
 
 
 def _pop_trailing_blank_lines(lines: list[str]) -> list[str]:

--- a/packages/markitdown-api/src/markitdown_api/rag_markdown.py
+++ b/packages/markitdown-api/src/markitdown_api/rag_markdown.py
@@ -29,7 +29,7 @@ def optimize_markdown_for_rag(
         marker = _fence_marker(raw_line)
         if fence_marker:
             output.append(raw_line)
-            if marker == fence_marker:
+            if _is_closing_fence(marker, fence_marker):
                 fence_marker = None
             continue
         if marker:
@@ -93,7 +93,7 @@ def _merge_split_registered_terms(lines: list[str]) -> list[str]:
         marker = _fence_marker(line)
         if fence_marker:
             merged.append(line)
-            if marker == fence_marker:
+            if _is_closing_fence(marker, fence_marker):
                 fence_marker = None
             i += 1
             continue
@@ -103,15 +103,18 @@ def _merge_split_registered_terms(lines: list[str]) -> list[str]:
             i += 1
             continue
 
-        if line.strip() == "®" and i + 1 < len(lines):
+        if line.strip() == "®":
             blank_buffer = _pop_trailing_blank_lines(merged)
-            suffix = lines[i + 1].strip()
+            suffix = lines[i + 1].strip() if i + 1 < len(lines) else ""
             if merged and 1 <= len(suffix) <= 12:
                 previous = merged.pop().rstrip()
                 merged.append(f"{previous}® {suffix}")
                 i += 2
                 continue
             merged.extend(blank_buffer)
+            merged.append(line)
+            i += 1
+            continue
 
         if line.strip().startswith("®"):
             blank_buffer = _pop_trailing_blank_lines(merged)
@@ -132,7 +135,7 @@ def _non_fenced_lines(lines: list[str]):
     for line in lines:
         marker = _fence_marker(line)
         if fence_marker:
-            if marker == fence_marker:
+            if _is_closing_fence(marker, fence_marker):
                 fence_marker = None
             continue
         if marker:
@@ -147,7 +150,15 @@ def _fence_marker(line: str) -> str | None:
     match = _FENCE_RE.match(line)
     if not match:
         return None
-    return match.group("marker")[0]
+    return match.group("marker")
+
+
+def _is_closing_fence(marker: str | None, opening_marker: str) -> bool:
+    return (
+        marker is not None
+        and marker[0] == opening_marker[0]
+        and len(marker) >= len(opening_marker)
+    )
 
 
 def _pop_trailing_blank_lines(lines: list[str]) -> list[str]:

--- a/packages/markitdown-api/tests/test_oss_image_upload.py
+++ b/packages/markitdown-api/tests/test_oss_image_upload.py
@@ -98,7 +98,11 @@ def test_oss_image_uploader_uses_stable_hash_key_and_public_url():
         (
             expected_key,
             image_bytes,
-            {"Content-Type": "image/png", "x-oss-object-acl": "public-read"},
+            {
+                "Content-Disposition": "inline",
+                "Content-Type": "image/png",
+                "x-oss-object-acl": "public-read",
+            },
         )
     ]
     assert url == f"https://markitdown.oss-cn-hangzhou.aliyuncs.com/{expected_key}"

--- a/packages/markitdown-api/tests/test_oss_image_upload.py
+++ b/packages/markitdown-api/tests/test_oss_image_upload.py
@@ -1,0 +1,161 @@
+import base64
+import hashlib
+from datetime import datetime, timezone
+
+import pytest
+
+from markitdown import DocumentConverterResult
+from markitdown_api.api_converter import ApiConverter
+from markitdown_api.api_types import ConvertRequest
+from markitdown_api.oss_image_upload import (
+    OssImageUploader,
+    _credentials_provider_from_environment,
+    replace_data_images_with_oss_urls,
+)
+
+
+def test_replace_data_images_uploads_and_rewrites_markdown_image():
+    image_bytes = b"fake-png-bytes"
+    encoded = base64.b64encode(image_bytes).decode("ascii")
+    markdown = f'before ![chart](data:image/png;base64,{encoded} "Chart") after'
+
+    class FakeUploader:
+        def __init__(self):
+            self.calls = []
+
+        def upload_image(self, mimetype, content):
+            self.calls.append((mimetype, content))
+            return "https://cdn.example.com/images/chart.png"
+
+    uploader = FakeUploader()
+
+    rewritten = replace_data_images_with_oss_urls(
+        markdown, uploader_factory=lambda: uploader
+    )
+
+    assert rewritten == (
+        'before ![chart](https://cdn.example.com/images/chart.png "Chart") after'
+    )
+    assert uploader.calls == [("image/png", image_bytes)]
+
+
+def test_replace_data_images_keeps_data_uri_when_oss_is_unavailable():
+    image_bytes = b"fake-png-bytes"
+    encoded = base64.b64encode(image_bytes).decode("ascii")
+    markdown = f"![chart](data:image/png;base64,{encoded})"
+
+    def unavailable_uploader():
+        raise ValueError("OSS_ENDPOINT is not set")
+
+    assert (
+        replace_data_images_with_oss_urls(
+            markdown, uploader_factory=unavailable_uploader
+        )
+        == markdown
+    )
+
+
+def test_replace_data_images_keeps_data_uri_when_single_upload_fails():
+    image_bytes = b"fake-png-bytes"
+    encoded = base64.b64encode(image_bytes).decode("ascii")
+    markdown = f"![chart](data:image/png;base64,{encoded})"
+
+    class FailingUploader:
+        def upload_image(self, mimetype, content):
+            raise RuntimeError("network timeout")
+
+    assert (
+        replace_data_images_with_oss_urls(markdown, uploader_factory=FailingUploader)
+        == markdown
+    )
+
+
+def test_oss_image_uploader_uses_stable_hash_key_and_public_url():
+    image_bytes = b"fake-png-bytes"
+    digest = hashlib.sha256(image_bytes).hexdigest()
+    fixed_now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+    class FakeBucket:
+        def __init__(self):
+            self.calls = []
+
+        def put_object(self, key, content, headers=None):
+            self.calls.append((key, content, headers))
+
+    bucket = FakeBucket()
+    uploader = OssImageUploader(
+        bucket=bucket,
+        endpoint="https://oss-cn-hangzhou.aliyuncs.com",
+        bucket_name="markitdown",
+        key_prefix="converted-images",
+        now=lambda: fixed_now,
+    )
+
+    url = uploader.upload_image("image/png", image_bytes)
+
+    expected_key = f"converted-images/2026/06/01/{digest}.png"
+    assert bucket.calls == [
+        (
+            expected_key,
+            image_bytes,
+            {"Content-Type": "image/png", "x-oss-object-acl": "public-read"},
+        )
+    ]
+    assert url == f"https://markitdown.oss-cn-hangzhou.aliyuncs.com/{expected_key}"
+
+
+def test_oss_image_uploader_rejects_unknown_image_mimetype():
+    uploader = OssImageUploader(
+        bucket=object(),
+        endpoint="https://oss-cn-hangzhou.aliyuncs.com",
+        bucket_name="markitdown",
+    )
+
+    with pytest.raises(ValueError, match="Unsupported image mimetype"):
+        uploader.upload_image("application/octet-stream", b"payload")
+
+
+def test_oss_credentials_provider_accepts_secret_access_key_alias(monkeypatch):
+    monkeypatch.setenv("OSS_ACCESS_KEY_ID", "access-key-id")
+    monkeypatch.delenv("OSS_ACCESS_KEY_SECRET", raising=False)
+    monkeypatch.setenv("OSS_SECRET_ACCESS_KEY", "secret-access-key")
+
+    import oss2
+
+    provider = _credentials_provider_from_environment(oss2.credentials)
+    credentials = provider.get_credentials()
+
+    assert credentials.get_access_key_id() == "access-key-id"
+    assert credentials.get_access_key_secret() == "secret-access-key"
+
+
+def test_convert_request_defaults_to_keep_data_uris_for_oss_fallback():
+    assert ConvertRequest().keep_data_uris is True
+
+
+def test_api_converter_rewrites_embedded_images_after_conversion(monkeypatch):
+    image_bytes = b"fake-png-bytes"
+    encoded = base64.b64encode(image_bytes).decode("ascii")
+    markdown = f"![chart](data:image/png;base64,{encoded})"
+    seen_kwargs = {}
+
+    class StubApiConverter(ApiConverter):
+        def _internal_convert(self, **kwargs):
+            seen_kwargs.update(kwargs)
+            return DocumentConverterResult(markdown=markdown)
+
+    def fake_replace(markdown_value):
+        assert markdown_value == markdown
+        return "![chart](https://cdn.example.com/images/chart.png)"
+
+    monkeypatch.setattr(
+        "markitdown_api.api_converter.replace_data_images_with_oss_urls",
+        fake_replace,
+    )
+
+    response = StubApiConverter(ConvertRequest()).convert()
+
+    assert seen_kwargs["keep_data_uris"] is True
+    assert (
+        response.result.markdown == "![chart](https://cdn.example.com/images/chart.png)"
+    )

--- a/packages/markitdown-api/tests/test_oss_image_upload.py
+++ b/packages/markitdown-api/tests/test_oss_image_upload.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+import logging
 from datetime import datetime, timezone
 
 import pytest
@@ -53,6 +54,30 @@ def test_replace_data_images_keeps_data_uri_when_oss_is_unavailable():
         )
         == markdown
     )
+
+
+def test_replace_data_images_logs_expected_oss_unavailable_fallback_as_info(caplog):
+    image_bytes = b"fake-png-bytes"
+    encoded = base64.b64encode(image_bytes).decode("ascii")
+    markdown = f"![chart](data:image/png;base64,{encoded})"
+
+    def unavailable_uploader():
+        raise ValueError("OSS_ENDPOINT is not set")
+
+    caplog.set_level(logging.INFO, logger="markitdown_api.oss_image_upload")
+
+    assert (
+        replace_data_images_with_oss_urls(
+            markdown, uploader_factory=unavailable_uploader
+        )
+        == markdown
+    )
+    assert any(
+        record.levelno == logging.INFO
+        and "OSS image uploader is unavailable" in record.message
+        for record in caplog.records
+    )
+    assert not any(record.levelno >= logging.WARNING for record in caplog.records)
 
 
 def test_replace_data_images_keeps_data_uri_when_single_upload_fails():
@@ -131,6 +156,19 @@ def test_oss_credentials_provider_accepts_secret_access_key_alias(monkeypatch):
 
     assert credentials.get_access_key_id() == "access-key-id"
     assert credentials.get_access_key_secret() == "secret-access-key"
+
+
+def test_oss_credentials_provider_missing_secret_mentions_both_supported_names(
+    monkeypatch,
+):
+    monkeypatch.setenv("OSS_ACCESS_KEY_ID", "access-key-id")
+    monkeypatch.delenv("OSS_ACCESS_KEY_SECRET", raising=False)
+    monkeypatch.delenv("OSS_SECRET_ACCESS_KEY", raising=False)
+
+    with pytest.raises(
+        ValueError, match="OSS_ACCESS_KEY_SECRET.*OSS_SECRET_ACCESS_KEY"
+    ):
+        _credentials_provider_from_environment(object())
 
 
 def test_convert_request_defaults_to_keep_data_uris_for_oss_fallback():

--- a/packages/markitdown-api/tests/test_rag_markdown.py
+++ b/packages/markitdown-api/tests/test_rag_markdown.py
@@ -113,6 +113,50 @@ def test_optimize_markdown_for_rag_preserves_fenced_code_blocks():
     )
 
 
+def test_optimize_markdown_for_rag_preserves_long_fences_with_shorter_inner_fence():
+    markdown = """Notebook
+
+````python
+print("before")
+```
+2
++
+````
+
+目录
+"""
+
+    assert (
+        optimize_markdown_for_rag(markdown, heading_keywords=["目录"])
+        == """# Notebook
+
+````python
+print("before")
+```
+2
++
+````
+
+## 目录"""
+    )
+
+
+def test_optimize_markdown_for_rag_does_not_merge_registered_mark_with_long_suffix():
+    markdown = """Product
+
+®
+this suffix is too long
+"""
+
+    assert (
+        optimize_markdown_for_rag(markdown)
+        == """# Product
+
+®
+this suffix is too long"""
+    )
+
+
 def test_api_converter_applies_rag_optimizer_by_default(monkeypatch):
     markdown = "产品目录\n2\n"
 

--- a/packages/markitdown-api/tests/test_rag_markdown.py
+++ b/packages/markitdown-api/tests/test_rag_markdown.py
@@ -62,6 +62,34 @@ def test_optimize_markdown_for_rag_does_not_remove_numbers_inside_tables():
     )
 
 
+def test_optimize_markdown_for_rag_preserves_fenced_code_blocks():
+    markdown = """Notebook
+2
+
+```python
+  print("hello")
+  2
++
+```
+
+目录
+3
+"""
+
+    assert (
+        optimize_markdown_for_rag(markdown)
+        == """# Notebook
+
+```python
+  print("hello")
+  2
++
+```
+
+## 目录"""
+    )
+
+
 def test_api_converter_applies_rag_optimizer_by_default(monkeypatch):
     markdown = "产品目录\n2\n"
 

--- a/packages/markitdown-api/tests/test_rag_markdown.py
+++ b/packages/markitdown-api/tests/test_rag_markdown.py
@@ -62,7 +62,7 @@ def test_optimize_markdown_for_rag_does_not_remove_numbers_inside_tables():
     )
 
 
-def test_api_converter_applies_rag_optimizer_only_when_enabled(monkeypatch):
+def test_api_converter_applies_rag_optimizer_by_default(monkeypatch):
     markdown = "产品目录\n2\n"
 
     class StubApiConverter(ApiConverter):
@@ -74,10 +74,10 @@ def test_api_converter_applies_rag_optimizer_only_when_enabled(monkeypatch):
         lambda markdown_value: markdown_value,
     )
 
-    assert StubApiConverter(ConvertRequest()).convert().result.markdown == markdown
+    assert StubApiConverter(ConvertRequest()).convert().result.markdown == "# 产品目录"
     assert (
-        StubApiConverter(ConvertRequest(rag=RagOptions(enabled=True)))
+        StubApiConverter(ConvertRequest(rag=RagOptions(enabled=False)))
         .convert()
         .result.markdown
-        == "# 产品目录"
+        == markdown
     )

--- a/packages/markitdown-api/tests/test_rag_markdown.py
+++ b/packages/markitdown-api/tests/test_rag_markdown.py
@@ -28,7 +28,7 @@ CE认证服务
 """
 
     assert (
-        optimize_markdown_for_rag(markdown)
+        optimize_markdown_for_rag(markdown, heading_keywords=["目录", "工业安全解决方案"])
         == """# 产品目录
 HELLO Industry
 
@@ -42,6 +42,29 @@ CE认证服务
 | 功能/版本 | 标准版 |
 | ----- | --- |
 | PL | Level e |"""
+    )
+
+
+def test_optimize_markdown_for_rag_does_not_embed_business_heading_keywords():
+    markdown = """产品目录
+
+工业通讯
+这个短行来自某个业务文档，不应被通用规则硬编码成标题。
+"""
+
+    assert (
+        optimize_markdown_for_rag(markdown)
+        == """# 产品目录
+
+工业通讯
+这个短行来自某个业务文档，不应被通用规则硬编码成标题。"""
+    )
+    assert (
+        optimize_markdown_for_rag(markdown, heading_keywords=["工业通讯"])
+        == """# 产品目录
+
+## 工业通讯
+这个短行来自某个业务文档，不应被通用规则硬编码成标题。"""
     )
 
 
@@ -77,7 +100,7 @@ def test_optimize_markdown_for_rag_preserves_fenced_code_blocks():
 """
 
     assert (
-        optimize_markdown_for_rag(markdown)
+        optimize_markdown_for_rag(markdown, heading_keywords=["目录"])
         == """# Notebook
 
 ```python
@@ -108,4 +131,24 @@ def test_api_converter_applies_rag_optimizer_by_default(monkeypatch):
         .convert()
         .result.markdown
         == markdown
+    )
+
+
+def test_api_converter_uses_configured_rag_heading_keywords(monkeypatch):
+    markdown = "产品目录\n\n目录\n"
+
+    class StubApiConverter(ApiConverter):
+        def _internal_convert(self, **kwargs):
+            return DocumentConverterResult(markdown=markdown)
+
+    monkeypatch.setattr(
+        "markitdown_api.api_converter.replace_data_images_with_oss_urls",
+        lambda markdown_value: markdown_value,
+    )
+
+    assert (
+        StubApiConverter(ConvertRequest(rag=RagOptions(heading_keywords=["目录"])))
+        .convert()
+        .result.markdown
+        == "# 产品目录\n\n## 目录"
     )

--- a/packages/markitdown-api/tests/test_rag_markdown.py
+++ b/packages/markitdown-api/tests/test_rag_markdown.py
@@ -1,0 +1,83 @@
+from markitdown import DocumentConverterResult
+
+from markitdown_api.api_converter import ApiConverter
+from markitdown_api.api_types import ConvertRequest, RagOptions
+from markitdown_api.rag_markdown import optimize_markdown_for_rag
+
+
+def test_optimize_markdown_for_rag_cleans_pdf_markdown_for_chunking():
+    markdown = """产品目录
+HELLO Industry
++
+2
+
+目录
+CE认证服务
+4
+
+![PDF page 4 image 1](https://cdn.example.com/page4.jpg)
+
+工业安全解决方案
+可编程安全控制器 -- sAMOs
+
+®
+ PRO
+| 功能/版本 | 标准版 |
+| ----- | --- |
+| PL | Level e |
+"""
+
+    assert (
+        optimize_markdown_for_rag(markdown)
+        == """# 产品目录
+HELLO Industry
+
+## 目录
+CE认证服务
+
+![CE认证服务 - PDF page 4 image 1](https://cdn.example.com/page4.jpg)
+
+## 工业安全解决方案
+可编程安全控制器 -- sAMOs® PRO
+| 功能/版本 | 标准版 |
+| ----- | --- |
+| PL | Level e |"""
+    )
+
+
+def test_optimize_markdown_for_rag_does_not_remove_numbers_inside_tables():
+    markdown = """参数
+| 页码 | 数值 |
+| --- | --- |
+| 4 | 24 V |
+5
+"""
+
+    assert (
+        optimize_markdown_for_rag(markdown)
+        == """# 参数
+| 页码 | 数值 |
+| --- | --- |
+| 4 | 24 V |"""
+    )
+
+
+def test_api_converter_applies_rag_optimizer_only_when_enabled(monkeypatch):
+    markdown = "产品目录\n2\n"
+
+    class StubApiConverter(ApiConverter):
+        def _internal_convert(self, **kwargs):
+            return DocumentConverterResult(markdown=markdown)
+
+    monkeypatch.setattr(
+        "markitdown_api.api_converter.replace_data_images_with_oss_urls",
+        lambda markdown_value: markdown_value,
+    )
+
+    assert StubApiConverter(ConvertRequest()).convert().result.markdown == markdown
+    assert (
+        StubApiConverter(ConvertRequest(rag=RagOptions(enabled=True)))
+        .convert()
+        .result.markdown
+        == "# 产品目录"
+    )

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -459,12 +459,15 @@ def _pdf_image_to_data_uri(image: Any) -> str | None:
     return f"data:{mimetype};base64,{payload}"
 
 
-def _extract_pdf_image_markdown(page: Any, page_number: int) -> list[str]:
+def _extract_pdf_image_markdown(
+    page: Any, page_number: int, page_has_text_layer: bool | None = None
+) -> list[str]:
     markdown_images: list[str] = []
-    try:
-        page_has_text_layer = bool((page.extract_text() or "").strip())
-    except Exception:
-        page_has_text_layer = False
+    if page_has_text_layer is None:
+        try:
+            page_has_text_layer = bool((page.extract_text() or "").strip())
+        except Exception:
+            page_has_text_layer = False
 
     for image_number, image in enumerate(getattr(page, "images", []) or [], start=1):
         if _is_obvious_framework_pdf_image(page, image, page_has_text_layer):
@@ -958,21 +961,26 @@ class PdfConverter(DocumentConverter):
             with pdfplumber.open(pdf_bytes) as pdf:
                 for page_idx, page in enumerate(pdf.pages):
                     page_content = _extract_form_content_from_words(page)
-                    page_image_chunks = (
-                        _extract_pdf_image_markdown(page, page_idx + 1)
-                        if keep_data_uris
-                        else []
-                    )
 
                     if page_content is not None:
                         form_page_count += 1
+                        page_has_text_layer = bool(page_content.strip())
                         if page_content.strip():
                             markdown_chunks.append(page_content)
                     else:
                         plain_page_indices.append(page_idx)
                         text = page.extract_text()
+                        page_has_text_layer = bool((text or "").strip())
                         if text and text.strip():
                             markdown_chunks.append(text.strip())
+
+                    page_image_chunks = (
+                        _extract_pdf_image_markdown(
+                            page, page_idx + 1, page_has_text_layer
+                        )
+                        if keep_data_uris
+                        else []
+                    )
 
                     if page_image_chunks:
                         markdown_chunks.extend(page_image_chunks)

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -1,5 +1,7 @@
 import sys
+import base64
 import io
+import os
 import re
 from typing import BinaryIO, Any
 
@@ -62,9 +64,17 @@ _dependency_exc_info = None
 try:
     import pdfminer
     import pdfminer.high_level
+    from pdfminer.pdftypes import resolve1
     import pdfplumber
 except ImportError:
     _dependency_exc_info = sys.exc_info()
+
+try:
+    from PIL import Image, ImageChops, ImageStat
+except ImportError:
+    Image = None
+    ImageChops = None
+    ImageStat = None
 
 
 ACCEPTED_MIME_TYPE_PREFIXES = [
@@ -73,6 +83,399 @@ ACCEPTED_MIME_TYPE_PREFIXES = [
 ]
 
 ACCEPTED_FILE_EXTENSIONS = [".pdf"]
+
+
+def _pdf_name(value: Any) -> str:
+    name = getattr(value, "name", None)
+    if name is None:
+        name = str(value)
+    return str(name).strip("/'\"")
+
+
+def _pdf_filter_names(filters: Any) -> list[str]:
+    if filters is None:
+        return []
+
+    if not isinstance(filters, (list, tuple)):
+        filters = [filters]
+
+    names: list[str] = []
+    for pdf_filter in filters:
+        names.append(_pdf_name(pdf_filter))
+
+    return names
+
+
+def _resolve_pdf_value(value: Any) -> Any:
+    try:
+        return resolve1(value)
+    except Exception:
+        return value
+
+
+def _detect_image_mimetype(data: bytes) -> str | None:
+    if data.startswith(b"\xff\xd8"):
+        return "image/jpeg"
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if data.startswith(b"RIFF") and data[8:12] == b"WEBP":
+        return "image/webp"
+    if data.startswith(b"BM"):
+        return "image/bmp"
+    return None
+
+
+def _cmyk_to_rgb_components(
+    cyan: int, magenta: int, yellow: int, black: int
+) -> tuple[int, int, int]:
+    return (
+        255 - min(255, cyan + black),
+        255 - min(255, magenta + black),
+        255 - min(255, yellow + black),
+    )
+
+
+def _indexed_pdf_image_to_pil(
+    data: bytes, width: int, height: int, colorspace: list[Any]
+) -> Any | None:
+    if len(colorspace) < 4:
+        return None
+
+    base_colorspace = _resolve_pdf_value(colorspace[1])
+    color_count = int(colorspace[2]) + 1
+    lookup = _resolve_pdf_value(colorspace[3])
+
+    if hasattr(lookup, "get_data"):
+        palette_bytes = lookup.get_data()
+    elif isinstance(lookup, bytes):
+        palette_bytes = lookup
+    elif isinstance(lookup, str):
+        palette_bytes = lookup.encode("latin1")
+    else:
+        return None
+
+    base_name = _pdf_name(base_colorspace)
+    components = {
+        "DeviceRGB": 3,
+        "DeviceCMYK": 4,
+        "DeviceGray": 1,
+    }.get(base_name)
+    if components is None:
+        return None
+
+    palette: list[int] = []
+    for index in range(min(color_count, 256)):
+        start = index * components
+        color = palette_bytes[start : start + components]
+        if len(color) < components:
+            break
+
+        if base_name == "DeviceRGB":
+            palette.extend(color[:3])
+        elif base_name == "DeviceCMYK":
+            palette.extend(_cmyk_to_rgb_components(*color[:4]))
+        else:
+            shade = color[0]
+            palette.extend([shade, shade, shade])
+
+    if not palette:
+        return None
+
+    palette.extend([0] * (768 - len(palette)))
+    image = Image.frombytes("P", (width, height), data)
+    image.putpalette(palette[:768])
+    return image.convert("RGB")
+
+
+def _flate_pdf_image_to_png(data: bytes, attrs: dict[Any, Any]) -> bytes | None:
+    image = _flate_pdf_image_to_pil(data, attrs)
+    if image is None:
+        return None
+
+    png_stream = io.BytesIO()
+    image.save(png_stream, format="PNG")
+    return png_stream.getvalue()
+
+
+def _flate_pdf_image_to_pil(data: bytes, attrs: dict[Any, Any]) -> Any | None:
+    if Image is None:
+        return None
+
+    dimensions = _pdf_stream_dimensions(attrs)
+    if dimensions is None:
+        return None
+
+    width, height = dimensions
+    colorspace = _resolve_pdf_value(attrs.get("ColorSpace"))
+    image = None
+
+    if isinstance(colorspace, list) and _pdf_name(colorspace[0]) == "Indexed":
+        if len(data) != width * height:
+            return None
+        image = _indexed_pdf_image_to_pil(data, width, height, colorspace)
+    else:
+        colorspace_name = _pdf_name(colorspace)
+        modes = {
+            "DeviceRGB": ("RGB", 3),
+            "DeviceCMYK": ("CMYK", 4),
+            "DeviceGray": ("L", 1),
+        }
+        mode_info = modes.get(colorspace_name)
+        if mode_info is None:
+            return None
+
+        mode, components = mode_info
+        if len(data) != width * height * components:
+            return None
+
+        image = Image.frombytes(mode, (width, height), data)
+        if mode == "CMYK":
+            image = image.convert("RGB")
+
+    return image
+
+
+def _dct_cmyk_pdf_image_to_jpeg(data: bytes, attrs: dict[Any, Any]) -> bytes | None:
+    if Image is None or ImageChops is None:
+        return None
+
+    colorspace = _resolve_pdf_value(attrs.get("ColorSpace"))
+    if _pdf_name(colorspace) != "DeviceCMYK":
+        return None
+
+    try:
+        image = Image.open(io.BytesIO(data))
+        image.load()
+    except Exception:
+        return None
+
+    if image.mode != "CMYK":
+        return None
+
+    white = Image.new("CMYK", image.size, (255, 255, 255, 255))
+    image = ImageChops.subtract(white, image).convert("RGB")
+
+    jpeg_stream = io.BytesIO()
+    image.save(jpeg_stream, format="JPEG", quality=95, optimize=True)
+    return jpeg_stream.getvalue()
+
+
+def _image_mimetype_from_pdf_filter(filters: Any) -> str | None:
+    filter_names = _pdf_filter_names(filters)
+    if "DCTDecode" in filter_names:
+        return "image/jpeg"
+
+    # Only direct browser-friendly image streams are emitted here. Other PDF
+    # image filters often represent raw pixel planes, not standalone files.
+    return None
+
+
+def _pdf_image_filter_enabled() -> bool:
+    raw = os.environ.get("PDF_IMAGE_FILTER_ENABLED", "true")
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _pdf_stream_dimensions(attrs: dict[Any, Any]) -> tuple[int, int] | None:
+    try:
+        width = int(_resolve_pdf_value(attrs.get("Width")))
+        height = int(_resolve_pdf_value(attrs.get("Height")))
+        bits = int(_resolve_pdf_value(attrs.get("BitsPerComponent", 8)))
+    except Exception:
+        return None
+
+    if width <= 0 or height <= 0 or bits != 8:
+        return None
+
+    return width, height
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _pdf_image_dimensions(image: Any) -> tuple[float | None, float | None]:
+    if not isinstance(image, dict):
+        return None, None
+
+    width = _float_or_none(image.get("width"))
+    height = _float_or_none(image.get("height"))
+
+    if width is None:
+        x0 = _float_or_none(image.get("x0"))
+        x1 = _float_or_none(image.get("x1"))
+        if x0 is not None and x1 is not None:
+            width = abs(x1 - x0)
+
+    if height is None:
+        top = _float_or_none(image.get("top"))
+        bottom = _float_or_none(image.get("bottom"))
+        if top is not None and bottom is not None:
+            height = abs(bottom - top)
+        else:
+            y0 = _float_or_none(image.get("y0"))
+            y1 = _float_or_none(image.get("y1"))
+            if y0 is not None and y1 is not None:
+                height = abs(y1 - y0)
+
+    return width, height
+
+
+def _pdf_image_touches_page_edge(page: Any, image: dict[str, Any]) -> bool:
+    page_width = _float_or_none(getattr(page, "width", None))
+    page_height = _float_or_none(getattr(page, "height", None))
+    x0 = _float_or_none(image.get("x0"))
+    x1 = _float_or_none(image.get("x1"))
+    top = _float_or_none(image.get("top"))
+    bottom = _float_or_none(image.get("bottom"))
+
+    tolerance = 2.0
+    touches_left = x0 is not None and x0 <= tolerance
+    touches_top = top is not None and top <= tolerance
+    touches_right = (
+        page_width is not None and x1 is not None and page_width - x1 <= tolerance
+    )
+    touches_bottom = (
+        page_height is not None
+        and bottom is not None
+        and page_height - bottom <= tolerance
+    )
+    return touches_left or touches_top or touches_right or touches_bottom
+
+
+def _is_obvious_framework_pdf_image(
+    page: Any, image: Any, page_has_text_layer: bool
+) -> bool:
+    if not _pdf_image_filter_enabled() or not isinstance(image, dict):
+        return False
+
+    width, height = _pdf_image_dimensions(image)
+    if width is None or height is None or width <= 0 or height <= 0:
+        return False
+
+    if width <= 3 or height <= 3:
+        return True
+
+    page_width = _float_or_none(getattr(page, "width", None))
+    page_height = _float_or_none(getattr(page, "height", None))
+    page_area = (page_width or 0) * (page_height or 0)
+    area_ratio = (width * height / page_area) if page_area else 0
+    max_dimension = max(width, height)
+    aspect_ratio = max(width / height, height / width)
+
+    if aspect_ratio >= 25 and area_ratio <= 0.035:
+        return True
+
+    if area_ratio <= 0.0015 and max_dimension <= 80:
+        return True
+
+    if _is_low_contrast_flate_mask(image):
+        return True
+
+    if (
+        page_has_text_layer
+        and area_ratio >= 0.90
+        and _pdf_image_touches_page_edge(page, image)
+    ):
+        return True
+
+    return False
+
+
+def _is_low_contrast_flate_mask(image: Any) -> bool:
+    if ImageStat is None or not isinstance(image, dict):
+        return False
+
+    stream = image.get("stream")
+    if stream is None:
+        return False
+
+    attrs = getattr(stream, "attrs", {})
+    filters = attrs.get("Filter")
+    if "FlateDecode" not in _pdf_filter_names(filters):
+        return False
+
+    colorspace = _resolve_pdf_value(attrs.get("ColorSpace"))
+    if not (isinstance(colorspace, list) and _pdf_name(colorspace[0]) == "Indexed"):
+        return False
+
+    try:
+        data = stream.get_data()
+    except Exception:
+        return False
+
+    image_value = _flate_pdf_image_to_pil(data, attrs)
+    if image_value is None:
+        return False
+
+    sample = image_value.convert("RGB").resize((64, 64))
+    rgb_stat = ImageStat.Stat(sample)
+    mean = rgb_stat.mean
+    channel_spread = max(mean) - min(mean)
+    luminance_stddev = ImageStat.Stat(sample.convert("L")).stddev[0]
+
+    return channel_spread <= 10 and 12 <= luminance_stddev <= 45
+
+
+def _pdf_image_to_data_uri(image: Any) -> str | None:
+    stream = image.get("stream") if isinstance(image, dict) else None
+    if stream is None:
+        return None
+
+    try:
+        data = stream.get_data()
+    except Exception:
+        return None
+
+    if not data:
+        return None
+
+    attrs = getattr(stream, "attrs", {})
+    filters = attrs.get("Filter")
+    if "DCTDecode" in _pdf_filter_names(filters):
+        jpeg_data = _dct_cmyk_pdf_image_to_jpeg(data, attrs)
+        if jpeg_data is not None:
+            payload = base64.b64encode(jpeg_data).decode("ascii")
+            return f"data:image/jpeg;base64,{payload}"
+
+    mimetype = _image_mimetype_from_pdf_filter(filters)
+    if mimetype is None:
+        mimetype = _detect_image_mimetype(data)
+    if mimetype is None:
+        if "FlateDecode" in _pdf_filter_names(filters):
+            png_data = _flate_pdf_image_to_png(data, attrs)
+            if png_data is None:
+                return None
+            data = png_data
+            mimetype = "image/png"
+        else:
+            return None
+
+    payload = base64.b64encode(data).decode("ascii")
+    return f"data:{mimetype};base64,{payload}"
+
+
+def _extract_pdf_image_markdown(page: Any, page_number: int) -> list[str]:
+    markdown_images: list[str] = []
+    try:
+        page_has_text_layer = bool((page.extract_text() or "").strip())
+    except Exception:
+        page_has_text_layer = False
+
+    for image_number, image in enumerate(getattr(page, "images", []) or [], start=1):
+        if _is_obvious_framework_pdf_image(page, image, page_has_text_layer):
+            continue
+
+        data_uri = _pdf_image_to_data_uri(image)
+        if data_uri is None:
+            continue
+        alt_text = f"PDF page {page_number} image {image_number}"
+        markdown_images.append(f"![{alt_text}]({data_uri})")
+    return markdown_images
 
 
 def _to_markdown_table(table: list[list[str]], include_separator: bool = True) -> str:
@@ -496,6 +899,7 @@ class PdfConverter(DocumentConverter):
     """
     Converts PDFs to Markdown.
     Supports extracting tables into aligned Markdown format (via pdfplumber).
+    Preserves directly embedded images as data URIs when keep_data_uris=True.
     Falls back to pdfminer if pdfplumber is missing or fails.
     """
 
@@ -538,6 +942,7 @@ class PdfConverter(DocumentConverter):
 
         # Read file stream into BytesIO for compatibility with pdfplumber
         pdf_bytes = io.BytesIO(file_stream.read())
+        keep_data_uris = kwargs.get("keep_data_uris", False)
 
         try:
             # Single pass: check every page for form-style content.
@@ -546,12 +951,18 @@ class PdfConverter(DocumentConverter):
             # after each page to free pdfplumber's cached objects and
             # keep memory usage constant regardless of page count.
             markdown_chunks: list[str] = []
+            image_chunks: list[str] = []
             form_page_count = 0
             plain_page_indices: list[int] = []
 
             with pdfplumber.open(pdf_bytes) as pdf:
                 for page_idx, page in enumerate(pdf.pages):
                     page_content = _extract_form_content_from_words(page)
+                    page_image_chunks = (
+                        _extract_pdf_image_markdown(page, page_idx + 1)
+                        if keep_data_uris
+                        else []
+                    )
 
                     if page_content is not None:
                         form_page_count += 1
@@ -563,6 +974,10 @@ class PdfConverter(DocumentConverter):
                         if text and text.strip():
                             markdown_chunks.append(text.strip())
 
+                    if page_image_chunks:
+                        markdown_chunks.extend(page_image_chunks)
+                        image_chunks.extend(page_image_chunks)
+
                     page.close()  # Free cached page data immediately
 
             # If no pages had form-style content, use pdfminer for
@@ -570,6 +985,11 @@ class PdfConverter(DocumentConverter):
             if form_page_count == 0:
                 pdf_bytes.seek(0)
                 markdown = pdfminer.high_level.extract_text(pdf_bytes)
+                if image_chunks:
+                    image_markdown = "\n\n".join(image_chunks)
+                    markdown = "\n\n".join(
+                        chunk for chunk in [markdown.strip(), image_markdown] if chunk
+                    )
             else:
                 markdown = "\n\n".join(markdown_chunks).strip()
 

--- a/packages/markitdown/tests/test_pdf_memory.py
+++ b/packages/markitdown/tests/test_pdf_memory.py
@@ -327,6 +327,33 @@ class TestPdfMemoryOptimization:
         assert "Plain text content" in result.text_content
         assert "![PDF page 1 image 1](data:image/jpeg;base64," in result.text_content
 
+    def test_keep_data_uris_reuses_page_text_for_image_filtering(self):
+        """Plain pages with images should extract page text only once."""
+        page = _make_plain_page()
+        page.images = [
+            {"stream": _FakePdfImageStream(b"\xff\xd8fake jpeg", "DCTDecode")}
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert page.extract_text.call_count == 1
+
     def test_pdf_images_are_not_emitted_by_default(self):
         """The core converter default should remain text-only for PDF images."""
         page = _make_plain_page()

--- a/packages/markitdown/tests/test_pdf_memory.py
+++ b/packages/markitdown/tests/test_pdf_memory.py
@@ -23,6 +23,10 @@ from markitdown import MarkItDown
 TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 
 
+def _require_pillow():
+    return pytest.importorskip("PIL.Image")
+
+
 def _has_fpdf2() -> bool:
     try:
         import fpdf  # noqa: F401
@@ -383,6 +387,7 @@ class TestPdfMemoryOptimization:
 
     def test_keep_data_uris_converts_flate_cmyk_pdf_images_to_png(self):
         """Raw FlateDecode PDF image streams should be emitted as PNG data URIs."""
+        _require_pillow()
         page = _make_plain_page()
         page.images = [
             {
@@ -420,7 +425,7 @@ class TestPdfMemoryOptimization:
 
     def test_keep_data_uris_converts_dct_cmyk_pdf_images_to_rgb_jpeg(self):
         """CMYK JPEG streams from PDFs should be normalized for browser display."""
-        from PIL import Image
+        Image = _require_pillow()
 
         jpeg_stream = io.BytesIO()
         Image.new("CMYK", (1, 1), (255, 255, 255, 255)).save(jpeg_stream, format="JPEG")
@@ -497,6 +502,7 @@ class TestPdfMemoryOptimization:
 
     def test_pdf_image_filter_skips_low_contrast_flate_shadow_masks(self):
         """Soft gray Flate/Indexed masks are PDF rendering layers, not content."""
+        _require_pillow()
         width = 100
         height = 100
         data = bytearray([0] * (width * height))
@@ -536,6 +542,7 @@ class TestPdfMemoryOptimization:
 
     def test_pdf_image_filter_keeps_high_contrast_flate_images(self):
         """High-contrast Flate/Indexed images such as QR codes should remain."""
+        _require_pillow()
         width = 100
         height = 100
         data = bytes((x + y) % 2 for y in range(height) for x in range(width))

--- a/packages/markitdown/tests/test_pdf_memory.py
+++ b/packages/markitdown/tests/test_pdf_memory.py
@@ -11,6 +11,8 @@ Verifies that:
 import gc
 import io
 import os
+import base64
+import re
 import tracemalloc
 
 import pytest
@@ -34,6 +36,7 @@ def _make_form_page():
     """Create a mock page with 3-column table-like word positions."""
     page = MagicMock()
     page.width = 612
+    page.height = 792
     page.close = MagicMock()
     page.extract_words.return_value = [
         {"text": "Name", "x0": 50, "x1": 100, "top": 10, "bottom": 20},
@@ -53,6 +56,7 @@ def _make_plain_page():
     """Create a mock page with single-line paragraph (no table structure)."""
     page = MagicMock()
     page.width = 612
+    page.height = 792
     page.close = MagicMock()
     page.extract_words.return_value = [
         {
@@ -65,6 +69,59 @@ def _make_plain_page():
     ]
     page.extract_text.return_value = "This is a long paragraph of plain text."
     return page
+
+
+class _FakePdfImageStream:
+    def __init__(self, data: bytes, pdf_filter: str, **attrs):
+        self.attrs = {"Filter": pdf_filter, **attrs}
+        self._data = data
+
+    def get_data(self):
+        return self._data
+
+
+def _make_pdf_image(
+    *,
+    x0: float,
+    top: float,
+    width: float,
+    height: float,
+    data: bytes = b"\xff\xd8fake jpeg",
+):
+    return {
+        "stream": _FakePdfImageStream(data, "DCTDecode"),
+        "x0": x0,
+        "x1": x0 + width,
+        "top": top,
+        "bottom": top + height,
+        "width": width,
+        "height": height,
+    }
+
+
+def _make_flate_indexed_cmyk_image(
+    *,
+    width: int,
+    height: int,
+    data: bytes,
+    palette: bytes,
+):
+    return {
+        "stream": _FakePdfImageStream(
+            data,
+            "FlateDecode",
+            Width=width,
+            Height=height,
+            BitsPerComponent=8,
+            ColorSpace=["Indexed", "DeviceCMYK", (len(palette) // 4) - 1, palette],
+        ),
+        "x0": 80,
+        "x1": 80 + width,
+        "top": 120,
+        "bottom": 120 + height,
+        "width": width,
+        "height": height,
+    }
 
 
 def _mock_pdfplumber_open(pages):
@@ -241,6 +298,280 @@ class TestPdfMemoryOptimization:
             f"Expected 1 pdfplumber.open call (single pass), "
             f"got {mock_pdfplumber.open.call_count}"
         )
+
+    def test_keep_data_uris_appends_pdf_images_to_plain_text_pdf(self):
+        """PDF images should be preserved as data URIs when requested."""
+        page = _make_plain_page()
+        page.images = [
+            {"stream": _FakePdfImageStream(b"\xff\xd8fake jpeg", "DCTDecode")}
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert "Plain text content" in result.text_content
+        assert "![PDF page 1 image 1](data:image/jpeg;base64," in result.text_content
+
+    def test_pdf_images_are_not_emitted_by_default(self):
+        """The core converter default should remain text-only for PDF images."""
+        page = _make_plain_page()
+        page.images = [
+            {"stream": _FakePdfImageStream(b"\xff\xd8fake jpeg", "DCTDecode")}
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+            )
+
+        assert "Plain text content" in result.text_content
+        assert "data:image/" not in result.text_content
+
+    def test_keep_data_uris_converts_flate_cmyk_pdf_images_to_png(self):
+        """Raw FlateDecode PDF image streams should be emitted as PNG data URIs."""
+        page = _make_plain_page()
+        page.images = [
+            {
+                "stream": _FakePdfImageStream(
+                    b"\x00\xff\xff\x00",
+                    "FlateDecode",
+                    Width=1,
+                    Height=1,
+                    BitsPerComponent=8,
+                    ColorSpace="DeviceCMYK",
+                )
+            }
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert "![PDF page 1 image 1](data:image/png;base64," in result.text_content
+        assert "iVBOR" in result.text_content
+
+    def test_keep_data_uris_converts_dct_cmyk_pdf_images_to_rgb_jpeg(self):
+        """CMYK JPEG streams from PDFs should be normalized for browser display."""
+        from PIL import Image
+
+        jpeg_stream = io.BytesIO()
+        Image.new("CMYK", (1, 1), (255, 255, 255, 255)).save(jpeg_stream, format="JPEG")
+        page = _make_plain_page()
+        page.images = [
+            {
+                "stream": _FakePdfImageStream(
+                    jpeg_stream.getvalue(),
+                    "DCTDecode",
+                    ColorSpace="DeviceCMYK",
+                )
+            }
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        match = re.search(
+            r"data:image/jpeg;base64,([A-Za-z0-9+/=]+)", result.text_content
+        )
+        assert match is not None
+
+        converted = Image.open(io.BytesIO(base64.b64decode(match.group(1)))).convert(
+            "RGB"
+        )
+        assert converted.getpixel((0, 0)) == (255, 255, 255)
+
+    def test_pdf_image_filter_skips_obvious_framework_images(self):
+        """PDF framework images should be skipped while content images remain."""
+        page = _make_plain_page()
+        page.images = [
+            _make_pdf_image(x0=10, top=10, width=1.5, height=700),
+            _make_pdf_image(x0=20, top=20, width=18, height=18),
+            _make_pdf_image(x0=80, top=120, width=240, height=140),
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert "![PDF page 1 image 1]" not in result.text_content
+        assert "![PDF page 1 image 2]" not in result.text_content
+        assert "![PDF page 1 image 3](data:image/jpeg;base64," in result.text_content
+        assert result.text_content.count("data:image/") == 1
+
+    def test_pdf_image_filter_skips_low_contrast_flate_shadow_masks(self):
+        """Soft gray Flate/Indexed masks are PDF rendering layers, not content."""
+        width = 100
+        height = 100
+        data = bytearray([0] * (width * height))
+        for y in range(20, 80):
+            for x in range(20, 80):
+                data[y * width + x] = 1
+
+        page = _make_plain_page()
+        page.images = [
+            _make_flate_indexed_cmyk_image(
+                width=width,
+                height=height,
+                data=bytes(data),
+                palette=bytes([0, 0, 0, 0, 80, 80, 80, 0]),
+            )
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert "data:image/" not in result.text_content
+
+    def test_pdf_image_filter_keeps_high_contrast_flate_images(self):
+        """High-contrast Flate/Indexed images such as QR codes should remain."""
+        width = 100
+        height = 100
+        data = bytes((x + y) % 2 for y in range(height) for x in range(width))
+
+        page = _make_plain_page()
+        page.images = [
+            _make_flate_indexed_cmyk_image(
+                width=width,
+                height=height,
+                data=data,
+                palette=bytes([0, 0, 0, 0, 0, 0, 0, 255]),
+            )
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert "![PDF page 1 image 1](data:image/png;base64," in result.text_content
+
+    def test_pdf_image_filter_can_be_disabled_with_environment(self, monkeypatch):
+        """Set PDF_IMAGE_FILTER_ENABLED=false to keep all extractable images."""
+        monkeypatch.setenv("PDF_IMAGE_FILTER_ENABLED", "false")
+        page = _make_plain_page()
+        page.images = [
+            _make_pdf_image(x0=10, top=10, width=1.5, height=700),
+            _make_pdf_image(x0=80, top=120, width=240, height=140),
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert "![PDF page 1 image 1](data:image/jpeg;base64," in result.text_content
+        assert "![PDF page 1 image 2](data:image/jpeg;base64," in result.text_content
 
     @pytest.mark.skipif(
         not os.path.exists(os.path.join(TEST_FILES_DIR, "test.pdf")),


### PR DESCRIPTION
## Summary

- Upload Markdown data-URI images produced by API conversions to Aliyun OSS when OSS is configured, while keeping the original data URI as the fallback path.
- Default `keep_data_uris` to `true` across API request models and file form endpoints so image extraction is available by default.
- Add PDF image extraction for `keep_data_uris=true`, including CMYK JPEG normalization, Flate image PNG emission, and lightweight filtering for obvious PDF framework/shadow artifacts.
- Add OSS upload configuration via environment variables, default uploaded object ACL to `public-read`, serve uploaded images with `Content-Disposition: inline`, and ignore `.idea/` in git.
- Enable basic RAG Markdown cleanup by default while allowing callers to disable it with `rag.enabled=false` or `rag_clean=false`.
- Keep RAG heading promotion generic: no built-in business-specific heading list; callers can pass exact `rag.heading_keywords` or file form `rag_heading_keywords` when a document family needs custom heading anchors.

## Configuration

OSS upload is enabled when these environment variables are available:

- `OSS_ACCESS_KEY_ID`
- `OSS_ACCESS_KEY_SECRET` or `OSS_SECRET_ACCESS_KEY`
- `OSS_ENDPOINT`
- `OSS_REGION`
- `OSS_BUCKET`

Optional settings:

- `OSS_IMAGE_KEY_PREFIX` defaults to `images`
- `OSS_PUBLIC_BASE_URL` overrides generated public URLs
- `OSS_OBJECT_ACL` defaults to `public-read`
- `PDF_IMAGE_FILTER_ENABLED=false` disables lightweight PDF artifact filtering

## RAG cleanup

RAG cleanup is enabled by default. It removes standalone page numbers/noise lines, merges split registered product names, preserves fenced code blocks, adds lightweight headings, and enriches generated PDF image alt text with nearby context.

For JSON endpoints, omit `rag` or pass:

```json
{"rag": {"enabled": true}}
```

To disable it:

```json
{"rag": {"enabled": false}}
```

To promote known exact headings without hardcoding them in the API:

```json
{"rag": {"enabled": true, "heading_keywords": ["目录", "联系我们"]}}
```

For `/convert/file` and `/convert/file/markdown`, form fields default to:

```text
rag_clean=true
rag_heading_keywords=
```

Set `rag_clean=false` to return the less-normalized conversion output. Set `rag_heading_keywords` to a comma-separated list for document-specific heading anchors.

## Validation

```bash
uv run --no-project --with pytest --with pdfplumber --with pdfminer.six --with pillow --with-editable ./packages/markitdown python -m pytest packages/markitdown/tests/test_pdf_memory.py::TestPdfMemoryOptimization -q
PYTHONPATH=packages/markitdown-api/src uv run --no-project --with pytest --with oss2 --with pydantic --with starlette --with openai --with pdfplumber --with pdfminer.six --with pillow --with-editable ./packages/markitdown python -m pytest packages/markitdown-api/tests -q
git diff --check
```
