### PR TITLE
fix(api): disable keep_data_uris by default

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/api_types.py
+++ b/packages/markitdown-api/src/markitdown_api/api_types.py
@@ -52,7 +52,7 @@ class ConvertRequest(BaseModel):
     )
     rag: RagOptions = Field(default_factory=RagOptions, description="RAG options")
     keep_data_uris: bool = Field(
-        default=True,
+        default=False,
         description="If keep_data_uris is True, use base64 encoding for images",
     )
     strict: bool = Field(

--- a/packages/markitdown-api/src/markitdown_api/convert_file.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_file.py
@@ -59,7 +59,7 @@ async def convert_file(
     openai_api_key: Annotated[str, Form()] = "",
     llm_model: Annotated[str, Form()] = "",
     llm_prompt: Annotated[str, Form()] = "",
-    keep_data_uris: Annotated[bool, Form()] = True,
+    keep_data_uris: Annotated[bool, Form()] = False,
     rag_clean: Annotated[bool, Form()] = True,
     rag_heading_keywords: Annotated[str, Form()] = "",
 ):
@@ -88,7 +88,7 @@ async def convert_file_markdown(
     openai_api_key: Annotated[str, Form()] = "",
     llm_model: Annotated[str, Form()] = "",
     llm_prompt: Annotated[str, Form()] = "",
-    keep_data_uris: Annotated[bool, Form()] = True,
+    keep_data_uris: Annotated[bool, Form()] = False,
     rag_clean: Annotated[bool, Form()] = True,
     rag_heading_keywords: Annotated[str, Form()] = "",
 ):

--- a/packages/markitdown-api/tests/test_oss_image_upload.py
+++ b/packages/markitdown-api/tests/test_oss_image_upload.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+import inspect
 import logging
 from datetime import datetime, timezone
 
@@ -8,6 +9,7 @@ import pytest
 from markitdown import DocumentConverterResult
 from markitdown_api.api_converter import ApiConverter
 from markitdown_api.api_types import ConvertRequest
+from markitdown_api.convert_file import convert_file, convert_file_markdown
 from markitdown_api.oss_image_upload import (
     OssImageUploader,
     _credentials_provider_from_environment,
@@ -171,8 +173,16 @@ def test_oss_credentials_provider_missing_secret_mentions_both_supported_names(
         _credentials_provider_from_environment(object())
 
 
-def test_convert_request_defaults_to_keep_data_uris_for_oss_fallback():
-    assert ConvertRequest().keep_data_uris is True
+def test_convert_request_disables_keep_data_uris_by_default():
+    assert ConvertRequest().keep_data_uris is False
+
+
+def test_file_upload_endpoints_disable_keep_data_uris_by_default():
+    assert inspect.signature(convert_file).parameters["keep_data_uris"].default is False
+    assert (
+        inspect.signature(convert_file_markdown).parameters["keep_data_uris"].default
+        is False
+    )
 
 
 def test_api_converter_rewrites_embedded_images_after_conversion(monkeypatch):
@@ -197,7 +207,7 @@ def test_api_converter_rewrites_embedded_images_after_conversion(monkeypatch):
 
     response = StubApiConverter(ConvertRequest()).convert()
 
-    assert seen_kwargs["keep_data_uris"] is True
+    assert seen_kwargs["keep_data_uris"] is False
     assert (
         response.result.markdown == "![chart](https://cdn.example.com/images/chart.png)"
     )


### PR DESCRIPTION
## Summary
- Disable `keep_data_uris` by default for API conversion requests.
- Align file upload endpoint form defaults with the request model default.
- Update OSS image upload tests to cover the new default and passthrough behavior.

## Changes
- API request model now defaults `ConvertRequest.keep_data_uris` to `False`.
- `/convert/file` and `/convert/file/markdown` form parameters now default `keep_data_uris` to `False`.
- Tests assert the request default, upload endpoint defaults, and converter kwargs passthrough.

## Testing
- `env -u OSS_PUBLIC_BASE_URL PYTHONPATH=packages/markitdown-api/src uv run --no-project --with pytest --with-editable 'packages/markitdown[all]' --with fastapi --with oss2 --with openai --with uvicorn --with python-multipart --with 'pydantic>=2' --with 'starlette>=0.40' pytest packages/markitdown-api/tests/test_oss_image_upload.py -q`

## Risk & Compatibility
- Behavior change: API clients that omitted `keep_data_uris` will no longer request embedded image data URIs by default.
- Explicitly passing `keep_data_uris=true` keeps the previous behavior available.

## Review Notes
- Check API default compatibility for clients that rely on inline base64 image output.
