### PR TITLE
fix(api): configure SSL verification for conversions

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/commons.py
+++ b/packages/markitdown-api/src/markitdown_api/commons.py
@@ -7,7 +7,7 @@ from markitdown import MarkItDown
 from markitdown_api.api_types import LlmOptions, ConvertRequest
 
 HTTP_VERIFY_SSL_ENV = "MARKITDOWN_API_HTTP_VERIFY_SSL"
-TRUE_VALUES = {"1", "true", "yes", "on"}
+FALSE_VALUES = {"0", "false", "no", "off"}
 
 
 def is_blank(s: str) -> bool:
@@ -22,7 +22,9 @@ def blank_then_none(s: str) -> str | None:
 
 def should_verify_http_ssl() -> bool:
     value = os.environ.get(HTTP_VERIFY_SSL_ENV)
-    return value is not None and value.strip().lower() in TRUE_VALUES
+    if value is None:
+        return True
+    return value.strip().lower() not in FALSE_VALUES
 
 
 def configure_markitdown_http_ssl(markitdown: MarkItDown) -> None:

--- a/packages/markitdown-api/src/markitdown_api/commons.py
+++ b/packages/markitdown-api/src/markitdown_api/commons.py
@@ -6,6 +6,9 @@ from openai import OpenAI
 from markitdown import MarkItDown
 from markitdown_api.api_types import LlmOptions, ConvertRequest
 
+HTTP_VERIFY_SSL_ENV = "MARKITDOWN_API_HTTP_VERIFY_SSL"
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
 
 def is_blank(s: str) -> bool:
     return not s or s.isspace()
@@ -15,6 +18,17 @@ def blank_then_none(s: str) -> str | None:
     if is_blank(s):
         return None
     return s
+
+
+def should_verify_http_ssl() -> bool:
+    value = os.environ.get(HTTP_VERIFY_SSL_ENV)
+    return value is not None and value.strip().lower() in TRUE_VALUES
+
+
+def configure_markitdown_http_ssl(markitdown: MarkItDown) -> None:
+    requests_session = getattr(markitdown, "_requests_session", None)
+    if requests_session is not None:
+        requests_session.verify = should_verify_http_ssl()
 
 
 def _build_markitdown(llm_options: Optional[LlmOptions] = None) -> MarkItDown:

--- a/packages/markitdown-api/src/markitdown_api/commons.py
+++ b/packages/markitdown-api/src/markitdown_api/commons.py
@@ -27,12 +27,6 @@ def should_verify_http_ssl() -> bool:
     return value.strip().lower() not in FALSE_VALUES
 
 
-def configure_markitdown_http_ssl(markitdown: MarkItDown) -> None:
-    requests_session = getattr(markitdown, "_requests_session", None)
-    if requests_session is not None:
-        requests_session.verify = should_verify_http_ssl()
-
-
 def _build_markitdown(llm_options: Optional[LlmOptions] = None) -> MarkItDown:
     base_url = api_key = llm_client = llm_model = llm_prompt = None
     if llm_options:

--- a/packages/markitdown-api/src/markitdown_api/convert_http.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_http.py
@@ -30,6 +30,7 @@ class HttpApiConverter(ApiConverter):
             method=self.request.method.value,
             url=self.request.url,
             headers=self.request.headers,
+            verify=False,
         )
         data_size = len(response.content)
         last_modified = _parse_last_modified_timestamp(response.headers)

--- a/packages/markitdown-api/src/markitdown_api/convert_http.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_http.py
@@ -1,4 +1,3 @@
-import os
 from typing import Annotated, Any
 
 import requests
@@ -18,15 +17,9 @@ from markitdown_api.api_types import (
 )
 from markitdown_api.convert_http_request import ConvertHttpRequest
 from markitdown_api.convert_yuque_api import YuQueApiConverter
+from markitdown_api.commons import should_verify_http_ssl
 
 TAG = "Convert Http"
-VERIFY_SSL_ENV = "MARKITDOWN_API_HTTP_VERIFY_SSL"
-TRUE_VALUES = {"1", "true", "yes", "on"}
-
-
-def _should_verify_ssl() -> bool:
-    value = os.environ.get(VERIFY_SSL_ENV)
-    return value is not None and value.strip().lower() in TRUE_VALUES
 
 
 class HttpApiConverter(ApiConverter):
@@ -38,7 +31,7 @@ class HttpApiConverter(ApiConverter):
             method=self.request.method.value,
             url=self.request.url,
             headers=self.request.headers,
-            verify=_should_verify_ssl(),
+            verify=should_verify_http_ssl(),
         )
         data_size = len(response.content)
         last_modified = _parse_last_modified_timestamp(response.headers)

--- a/packages/markitdown-api/src/markitdown_api/convert_http.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_http.py
@@ -1,3 +1,4 @@
+import os
 from typing import Annotated, Any
 
 import requests
@@ -19,6 +20,13 @@ from markitdown_api.convert_http_request import ConvertHttpRequest
 from markitdown_api.convert_yuque_api import YuQueApiConverter
 
 TAG = "Convert Http"
+VERIFY_SSL_ENV = "MARKITDOWN_API_HTTP_VERIFY_SSL"
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def _should_verify_ssl() -> bool:
+    value = os.environ.get(VERIFY_SSL_ENV)
+    return value is not None and value.strip().lower() in TRUE_VALUES
 
 
 class HttpApiConverter(ApiConverter):
@@ -30,7 +38,7 @@ class HttpApiConverter(ApiConverter):
             method=self.request.method.value,
             url=self.request.url,
             headers=self.request.headers,
-            verify=False,
+            verify=_should_verify_ssl(),
         )
         data_size = len(response.content)
         last_modified = _parse_last_modified_timestamp(response.headers)

--- a/packages/markitdown-api/src/markitdown_api/convert_uri.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_uri.py
@@ -10,6 +10,7 @@ from markitdown_api.api_types import (
     MarkdownResponse,
     ConvertResponse,
 )
+from markitdown_api.commons import configure_markitdown_http_ssl
 
 TAG = "Convert Uri"
 
@@ -33,6 +34,7 @@ class UriApiConverter(ApiConverter):
 
     def _internal_convert(self, **kwargs: Any) -> DocumentConverterResult:
         stream_info = StreamInfo(charset=self.request.charset)
+        configure_markitdown_http_ssl(self.markitdown)
         return self.markitdown.convert_uri(
             self.request.uri, stream_info=stream_info, **kwargs
         )

--- a/packages/markitdown-api/src/markitdown_api/convert_uri.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_uri.py
@@ -10,7 +10,7 @@ from markitdown_api.api_types import (
     MarkdownResponse,
     ConvertResponse,
 )
-from markitdown_api.commons import configure_markitdown_http_ssl
+from markitdown_api.commons import should_verify_http_ssl
 
 TAG = "Convert Uri"
 
@@ -34,7 +34,20 @@ class UriApiConverter(ApiConverter):
 
     def _internal_convert(self, **kwargs: Any) -> DocumentConverterResult:
         stream_info = StreamInfo(charset=self.request.charset)
-        configure_markitdown_http_ssl(self.markitdown)
+        if self.request.uri.startswith("http:") or self.request.uri.startswith(
+            "https:"
+        ):
+            response = self.markitdown._requests_session.get(
+                self.request.uri,
+                stream=True,
+                verify=should_verify_http_ssl(),
+            )
+            response.raise_for_status()
+            return self.markitdown.convert_response(
+                response,
+                stream_info=stream_info,
+                **kwargs,
+            )
         return self.markitdown.convert_uri(
             self.request.uri, stream_info=stream_info, **kwargs
         )

--- a/packages/markitdown-api/src/markitdown_api/convert_yuque_api.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_yuque_api.py
@@ -17,6 +17,7 @@ from markitdown_api.api_types import (
     ConvertResponse,
     StreamMetadata,
 )
+from markitdown_api.commons import should_verify_http_ssl
 from markitdown_api.convert_http_request import ConvertHttpRequest
 
 TAG = "Convert YuQue Doc"
@@ -37,6 +38,7 @@ class YuQueApiConverter(ApiConverter):
         response = requests.get(
             url=self.request.url,
             headers=self.request.headers,
+            verify=should_verify_http_ssl(),
         )
         result = response.json()
         if response.status_code != 200:
@@ -126,7 +128,7 @@ async def convert_yuque_book(url: str):
 
 
 def extract_yuque_app_data_url(url):
-    response = requests.get(url=url)
+    response = requests.get(url=url, verify=should_verify_http_ssl())
     result = response.content.decode("utf-8")
     if response.status_code != 200:
         raise Exception(f"Failed to get YuQue API URL: {response.status_code} {result}")

--- a/packages/markitdown-api/tests/test_convert_http.py
+++ b/packages/markitdown-api/tests/test_convert_http.py
@@ -41,7 +41,7 @@ def _convert_and_capture_http_request(monkeypatch):
     return request_calls[0]
 
 
-def test_http_converter_disables_ssl_verification_by_default(monkeypatch):
+def test_http_converter_enables_ssl_verification_by_default(monkeypatch):
     monkeypatch.delenv(HTTP_VERIFY_SSL_ENV, raising=False)
 
     request_call = _convert_and_capture_http_request(monkeypatch)
@@ -50,11 +50,11 @@ def test_http_converter_disables_ssl_verification_by_default(monkeypatch):
         "method": "get",
         "url": "https://example.invalid/",
         "headers": {"Accept": "text/html"},
-        "verify": False,
+        "verify": True,
     }
 
 
-def test_http_converter_enables_ssl_verification_when_configured(monkeypatch):
+def test_http_converter_enables_ssl_verification_when_configured_true(monkeypatch):
     monkeypatch.setenv(HTTP_VERIFY_SSL_ENV, "true")
 
     request_call = _convert_and_capture_http_request(monkeypatch)
@@ -64,4 +64,17 @@ def test_http_converter_enables_ssl_verification_when_configured(monkeypatch):
         "url": "https://example.invalid/",
         "headers": {"Accept": "text/html"},
         "verify": True,
+    }
+
+
+def test_http_converter_disables_ssl_verification_when_configured_false(monkeypatch):
+    monkeypatch.setenv(HTTP_VERIFY_SSL_ENV, "false")
+
+    request_call = _convert_and_capture_http_request(monkeypatch)
+
+    assert request_call == {
+        "method": "get",
+        "url": "https://example.invalid/",
+        "headers": {"Accept": "text/html"},
+        "verify": False,
     }

--- a/packages/markitdown-api/tests/test_convert_http.py
+++ b/packages/markitdown-api/tests/test_convert_http.py
@@ -3,8 +3,10 @@ from markitdown import DocumentConverterResult
 from markitdown_api.convert_http import HttpApiConverter
 from markitdown_api.convert_http_request import ConvertHttpRequest
 
+VERIFY_SSL_ENV = "MARKITDOWN_API_HTTP_VERIFY_SSL"
 
-def test_http_converter_disables_ssl_verification_explicitly(monkeypatch):
+
+def _convert_and_capture_http_request(monkeypatch):
     request_calls = []
     url = "https://example.invalid/"
 
@@ -36,11 +38,31 @@ def test_http_converter_disables_ssl_verification_explicitly(monkeypatch):
     )._internal_convert()
 
     assert result.markdown == "ok"
-    assert request_calls == [
-        {
-            "method": "get",
-            "url": url,
-            "headers": {"Accept": "text/html"},
-            "verify": False,
-        },
-    ]
+    assert len(request_calls) == 1
+    return request_calls[0]
+
+
+def test_http_converter_disables_ssl_verification_by_default(monkeypatch):
+    monkeypatch.delenv(VERIFY_SSL_ENV, raising=False)
+
+    request_call = _convert_and_capture_http_request(monkeypatch)
+
+    assert request_call == {
+        "method": "get",
+        "url": "https://example.invalid/",
+        "headers": {"Accept": "text/html"},
+        "verify": False,
+    }
+
+
+def test_http_converter_enables_ssl_verification_when_configured(monkeypatch):
+    monkeypatch.setenv(VERIFY_SSL_ENV, "true")
+
+    request_call = _convert_and_capture_http_request(monkeypatch)
+
+    assert request_call == {
+        "method": "get",
+        "url": "https://example.invalid/",
+        "headers": {"Accept": "text/html"},
+        "verify": True,
+    }

--- a/packages/markitdown-api/tests/test_convert_http.py
+++ b/packages/markitdown-api/tests/test_convert_http.py
@@ -1,0 +1,46 @@
+from markitdown import DocumentConverterResult
+
+from markitdown_api.convert_http import HttpApiConverter
+from markitdown_api.convert_http_request import ConvertHttpRequest
+
+
+def test_http_converter_disables_ssl_verification_explicitly(monkeypatch):
+    request_calls = []
+    url = "https://example.invalid/"
+
+    class FakeResponse:
+        content = b"<html>ok</html>"
+        headers = {"Content-Type": "text/html; charset=utf-8"}
+
+    response = FakeResponse()
+
+    class FakeMarkItDown:
+        def convert_response(self, response, stream_info, **kwargs):
+            return DocumentConverterResult(markdown="ok")
+
+    def fake_request(**kwargs):
+        request_calls.append(kwargs)
+        return response
+
+    monkeypatch.setattr(
+        "markitdown_api.api_converter.build_markitdown",
+        lambda request: FakeMarkItDown(),
+    )
+    monkeypatch.setattr("markitdown_api.convert_http.requests.request", fake_request)
+
+    result = HttpApiConverter(
+        ConvertHttpRequest(
+            url=url,
+            headers={"Accept": "text/html"},
+        )
+    )._internal_convert()
+
+    assert result.markdown == "ok"
+    assert request_calls == [
+        {
+            "method": "get",
+            "url": url,
+            "headers": {"Accept": "text/html"},
+            "verify": False,
+        },
+    ]

--- a/packages/markitdown-api/tests/test_convert_http.py
+++ b/packages/markitdown-api/tests/test_convert_http.py
@@ -1,9 +1,8 @@
 from markitdown import DocumentConverterResult
 
+from markitdown_api.commons import HTTP_VERIFY_SSL_ENV
 from markitdown_api.convert_http import HttpApiConverter
 from markitdown_api.convert_http_request import ConvertHttpRequest
-
-VERIFY_SSL_ENV = "MARKITDOWN_API_HTTP_VERIFY_SSL"
 
 
 def _convert_and_capture_http_request(monkeypatch):
@@ -43,7 +42,7 @@ def _convert_and_capture_http_request(monkeypatch):
 
 
 def test_http_converter_disables_ssl_verification_by_default(monkeypatch):
-    monkeypatch.delenv(VERIFY_SSL_ENV, raising=False)
+    monkeypatch.delenv(HTTP_VERIFY_SSL_ENV, raising=False)
 
     request_call = _convert_and_capture_http_request(monkeypatch)
 
@@ -56,7 +55,7 @@ def test_http_converter_disables_ssl_verification_by_default(monkeypatch):
 
 
 def test_http_converter_enables_ssl_verification_when_configured(monkeypatch):
-    monkeypatch.setenv(VERIFY_SSL_ENV, "true")
+    monkeypatch.setenv(HTTP_VERIFY_SSL_ENV, "true")
 
     request_call = _convert_and_capture_http_request(monkeypatch)
 

--- a/packages/markitdown-api/tests/test_convert_uri.py
+++ b/packages/markitdown-api/tests/test_convert_uri.py
@@ -4,17 +4,29 @@ from markitdown_api.commons import HTTP_VERIFY_SSL_ENV
 from markitdown_api.convert_uri import ConvertUriRequest, UriApiConverter
 
 
-def _convert_and_capture_session_verify(monkeypatch):
+def _convert_and_capture_session_get_request(monkeypatch):
     captured = {}
 
+    class FakeResponse:
+        headers = {"Content-Type": "application/pdf"}
+
+        def raise_for_status(self):
+            captured["raised_for_status"] = True
+
     class FakeRequestSession:
-        verify = True
+        def get(self, *args, **kwargs):
+            captured["get"] = {"args": args, "kwargs": kwargs}
+            return FakeResponse()
 
     class FakeMarkItDown:
         def __init__(self):
             self._requests_session = FakeRequestSession()
 
         def convert_uri(self, uri, stream_info, **kwargs):
+            raise AssertionError("HTTP URI requests must pass verify explicitly")
+
+        def convert_response(self, response, stream_info, **kwargs):
+            captured["response"] = response
             return DocumentConverterResult(markdown="ok")
 
     def fake_build_markitdown(request):
@@ -32,28 +44,38 @@ def _convert_and_capture_session_verify(monkeypatch):
     )._internal_convert()
 
     assert result.markdown == "ok"
-    return captured["markitdown"]._requests_session.verify
+    assert captured["raised_for_status"] is True
+    return captured["get"]
 
 
 def test_uri_converter_enables_ssl_verification_by_default(monkeypatch):
     monkeypatch.delenv(HTTP_VERIFY_SSL_ENV, raising=False)
 
-    verify = _convert_and_capture_session_verify(monkeypatch)
+    request_call = _convert_and_capture_session_get_request(monkeypatch)
 
-    assert verify is True
+    assert request_call == {
+        "args": ("https://example.invalid/document.pdf",),
+        "kwargs": {"stream": True, "verify": True},
+    }
 
 
 def test_uri_converter_enables_ssl_verification_when_configured_true(monkeypatch):
     monkeypatch.setenv(HTTP_VERIFY_SSL_ENV, "true")
 
-    verify = _convert_and_capture_session_verify(monkeypatch)
+    request_call = _convert_and_capture_session_get_request(monkeypatch)
 
-    assert verify is True
+    assert request_call == {
+        "args": ("https://example.invalid/document.pdf",),
+        "kwargs": {"stream": True, "verify": True},
+    }
 
 
 def test_uri_converter_disables_ssl_verification_when_configured_false(monkeypatch):
     monkeypatch.setenv(HTTP_VERIFY_SSL_ENV, "false")
 
-    verify = _convert_and_capture_session_verify(monkeypatch)
+    request_call = _convert_and_capture_session_get_request(monkeypatch)
 
-    assert verify is False
+    assert request_call == {
+        "args": ("https://example.invalid/document.pdf",),
+        "kwargs": {"stream": True, "verify": False},
+    }

--- a/packages/markitdown-api/tests/test_convert_uri.py
+++ b/packages/markitdown-api/tests/test_convert_uri.py
@@ -1,0 +1,51 @@
+from markitdown import DocumentConverterResult
+
+from markitdown_api.commons import HTTP_VERIFY_SSL_ENV
+from markitdown_api.convert_uri import ConvertUriRequest, UriApiConverter
+
+
+def _convert_and_capture_session_verify(monkeypatch):
+    captured = {}
+
+    class FakeRequestSession:
+        verify = True
+
+    class FakeMarkItDown:
+        def __init__(self):
+            self._requests_session = FakeRequestSession()
+
+        def convert_uri(self, uri, stream_info, **kwargs):
+            return DocumentConverterResult(markdown="ok")
+
+    def fake_build_markitdown(request):
+        markitdown = FakeMarkItDown()
+        captured["markitdown"] = markitdown
+        return markitdown
+
+    monkeypatch.setattr(
+        "markitdown_api.api_converter.build_markitdown",
+        fake_build_markitdown,
+    )
+
+    result = UriApiConverter(
+        ConvertUriRequest(uri="https://example.invalid/document.pdf")
+    )._internal_convert()
+
+    assert result.markdown == "ok"
+    return captured["markitdown"]._requests_session.verify
+
+
+def test_uri_converter_disables_ssl_verification_by_default(monkeypatch):
+    monkeypatch.delenv(HTTP_VERIFY_SSL_ENV, raising=False)
+
+    verify = _convert_and_capture_session_verify(monkeypatch)
+
+    assert verify is False
+
+
+def test_uri_converter_enables_ssl_verification_when_configured(monkeypatch):
+    monkeypatch.setenv(HTTP_VERIFY_SSL_ENV, "true")
+
+    verify = _convert_and_capture_session_verify(monkeypatch)
+
+    assert verify is True

--- a/packages/markitdown-api/tests/test_convert_uri.py
+++ b/packages/markitdown-api/tests/test_convert_uri.py
@@ -35,17 +35,25 @@ def _convert_and_capture_session_verify(monkeypatch):
     return captured["markitdown"]._requests_session.verify
 
 
-def test_uri_converter_disables_ssl_verification_by_default(monkeypatch):
+def test_uri_converter_enables_ssl_verification_by_default(monkeypatch):
     monkeypatch.delenv(HTTP_VERIFY_SSL_ENV, raising=False)
 
     verify = _convert_and_capture_session_verify(monkeypatch)
 
-    assert verify is False
+    assert verify is True
 
 
-def test_uri_converter_enables_ssl_verification_when_configured(monkeypatch):
+def test_uri_converter_enables_ssl_verification_when_configured_true(monkeypatch):
     monkeypatch.setenv(HTTP_VERIFY_SSL_ENV, "true")
 
     verify = _convert_and_capture_session_verify(monkeypatch)
 
     assert verify is True
+
+
+def test_uri_converter_disables_ssl_verification_when_configured_false(monkeypatch):
+    monkeypatch.setenv(HTTP_VERIFY_SSL_ENV, "false")
+
+    verify = _convert_and_capture_session_verify(monkeypatch)
+
+    assert verify is False

--- a/packages/markitdown-api/tests/test_convert_yuque_api.py
+++ b/packages/markitdown-api/tests/test_convert_yuque_api.py
@@ -1,0 +1,127 @@
+import json
+from urllib.parse import quote
+
+from markitdown import DocumentConverterResult
+
+from markitdown_api.commons import HTTP_VERIFY_SSL_ENV
+from markitdown_api.convert_http_request import ConvertHttpRequest
+from markitdown_api.convert_yuque_api import (
+    YuQueApiConverter,
+    extract_yuque_app_data_url,
+)
+
+
+def _convert_and_capture_yuque_request(monkeypatch):
+    request_calls = []
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "data": {
+                    "title": "Doc",
+                    "updated_at": "2025-05-19T07:20:41.000Z",
+                    "content": "<p>ok</p>",
+                }
+            }
+
+    class FakeMarkItDown:
+        def convert_stream(self, stream, stream_info, **kwargs):
+            return DocumentConverterResult(markdown="ok")
+
+    def fake_get(**kwargs):
+        request_calls.append(kwargs)
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "markitdown_api.api_converter.build_markitdown",
+        lambda request: FakeMarkItDown(),
+    )
+    monkeypatch.setattr("markitdown_api.convert_yuque_api.requests.get", fake_get)
+
+    result = YuQueApiConverter(
+        ConvertHttpRequest(
+            url="https://example.invalid/api/docs/doc",
+            headers={"Authorization": "Bearer token"},
+        )
+    )._internal_convert()
+
+    assert result.markdown == "ok"
+    assert len(request_calls) == 1
+    return request_calls[0]
+
+
+def test_yuque_converter_enables_ssl_verification_by_default(monkeypatch):
+    monkeypatch.delenv(HTTP_VERIFY_SSL_ENV, raising=False)
+
+    request_call = _convert_and_capture_yuque_request(monkeypatch)
+
+    assert request_call == {
+        "url": "https://example.invalid/api/docs/doc",
+        "headers": {"Authorization": "Bearer token"},
+        "verify": True,
+    }
+
+
+def test_yuque_converter_disables_ssl_verification_when_configured_false(
+    monkeypatch,
+):
+    monkeypatch.setenv(HTTP_VERIFY_SSL_ENV, "false")
+
+    request_call = _convert_and_capture_yuque_request(monkeypatch)
+
+    assert request_call == {
+        "url": "https://example.invalid/api/docs/doc",
+        "headers": {"Authorization": "Bearer token"},
+        "verify": False,
+    }
+
+
+def _extract_and_capture_yuque_book_request(monkeypatch):
+    request_calls = []
+    app_data = {
+        "organization": {"login": "example"},
+        "book": {"id": 1, "name": "Book", "toc": []},
+    }
+    encoded_app_data = quote(json.dumps(app_data))
+
+    class FakeResponse:
+        status_code = 200
+        content = (
+            f'window.appData = JSON.parse(decodeURIComponent("{encoded_app_data}"))'
+        ).encode("utf-8")
+
+    def fake_get(**kwargs):
+        request_calls.append(kwargs)
+        return FakeResponse()
+
+    monkeypatch.setattr("markitdown_api.convert_yuque_api.requests.get", fake_get)
+
+    assert extract_yuque_app_data_url("https://example.invalid/book") == app_data
+    assert len(request_calls) == 1
+    return request_calls[0]
+
+
+def test_yuque_book_fetch_enables_ssl_verification_by_default(monkeypatch):
+    monkeypatch.delenv(HTTP_VERIFY_SSL_ENV, raising=False)
+
+    request_call = _extract_and_capture_yuque_book_request(monkeypatch)
+
+    assert request_call == {
+        "url": "https://example.invalid/book",
+        "verify": True,
+    }
+
+
+def test_yuque_book_fetch_disables_ssl_verification_when_configured_false(
+    monkeypatch,
+):
+    monkeypatch.setenv(HTTP_VERIFY_SSL_ENV, "false")
+
+    request_call = _extract_and_capture_yuque_book_request(monkeypatch)
+
+    assert request_call == {
+        "url": "https://example.invalid/book",
+        "verify": False,
+    }


### PR DESCRIPTION
## Summary
- Keep outbound TLS certificate verification enabled by default for `/convert/http`, `/convert/uri`, and YuQue conversion fetches.
- Allow administrators to explicitly disable verification with `MARKITDOWN_API_HTTP_VERIFY_SSL=false` when needed for problematic conversion targets.
- Pass the configured SSL verification value explicitly to outbound request calls so environment CA bundle settings cannot override the disable flag.

## Changes
- Added shared `MARKITDOWN_API_HTTP_VERIFY_SSL` parsing in `markitdown_api.commons`.
- `/convert/http` passes the parsed value directly to `requests.request(..., verify=...)`.
- `/convert/uri` now handles HTTP(S) URI fetches through MarkItDown’s request session with an explicit `verify=...` argument before converting the response.
- YuQue document and book fetches pass the same explicit `verify=...` value.
- False-like environment values are `0`, `false`, `no`, and `off`; unset or other values keep verification enabled.
- Tests use reserved example URLs and do not expose any real target URL.

## Testing
- `env -u OSS_PUBLIC_BASE_URL PYTHONPATH=packages/markitdown-api/src uv run --no-project --with pytest --with-editable 'packages/markitdown[all]' --with fastapi --with oss2 --with openai --with uvicorn --with python-multipart --with 'pydantic>=2' --with 'starlette>=0.40' pytest packages/markitdown-api/tests -q`
- Commit hook: `black` passed.

## Risk & Compatibility
- Default behavior keeps TLS certificate and hostname verification enabled.
- Operators can set `MARKITDOWN_API_HTTP_VERIFY_SSL=false` to disable verification for environments that require this workaround.

## Review Notes
- Addressed review feedback to keep TLS verification enabled by default, pass URI fetch verification explicitly, and apply the flag to YuQue fetches.
