### PR TITLE
ci(docker): accelerate image deploy workflow

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -34,18 +34,21 @@ jobs:
         uses: actions/checkout@master
 
       - name: Set up QEMU
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -53,6 +56,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to AliyunCR
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
         with:
           registry: registry.cn-shanghai.aliyuncs.com
@@ -76,8 +80,10 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           context: packages
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=markitdown-api
+          cache-to: type=gha,mode=max,scope=markitdown-api


### PR DESCRIPTION
## Summary
- Add GitHub Actions cache for Docker Buildx to reuse image build layers across runs.
- Skip QEMU setup and registry logins on pull request builds, since PRs only need build validation.
- Build PRs for `linux/amd64` only while preserving multi-architecture image publishing for non-PR events.

## Changes
- Docker deploy workflow now uses `type=gha` cache with a stable `markitdown-api` scope.
- Pull request runs set `push: false`, avoiding registry uploads and credentials use.
- Tag, schedule, and manual dispatch runs continue pushing images and building `linux/amd64,linux/arm64`.

## Testing
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docker-deploy.yml'); puts 'yaml ok'"`\n- `git diff --check`\n\n## Risk & Compatibility\n- CI behavior changes for pull requests: PRs no longer push Docker images and only validate `linux/amd64`.\n- Release/tag, schedule, and manual workflow publishing behavior is preserved, including multi-architecture images and all configured registries.\n\n## Review Notes\n- Please verify the conditional platform expression behaves as expected in GitHub Actions.\n- Confirm PR runs should not publish temporary images.