### PR TITLE
fix(api): default HTTP referer for conversions

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/convert_http.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_http.py
@@ -1,7 +1,9 @@
 from typing import Annotated, Any
+from urllib.parse import urlsplit, urlunsplit
 
 import requests
 from fastapi import Body, APIRouter
+from requests.utils import CaseInsensitiveDict
 
 from markitdown import DocumentConverterResult, StreamInfo
 from markitdown_api._utils import (
@@ -22,17 +24,36 @@ from markitdown_api.commons import should_verify_http_ssl
 TAG = "Convert Http"
 
 
+def _same_origin_referer(url: str) -> str:
+    parts = urlsplit(url)
+    return urlunsplit((parts.scheme, parts.netloc, "/", "", ""))
+
+
+def _has_header(headers: dict | None, header_name: str) -> bool:
+    return header_name in CaseInsensitiveDict(headers or {})
+
+
+def _headers_with_same_origin_referer(url: str, headers: dict | None) -> dict:
+    request_headers = dict(headers or {})
+    if not _has_header(request_headers, "Referer"):
+        request_headers["Referer"] = _same_origin_referer(url)
+    return request_headers
+
+
 class HttpApiConverter(ApiConverter):
     def __init__(self, request: ConvertHttpRequest):
         super().__init__(request)
 
-    def _internal_convert(self, **kwargs: Any) -> DocumentConverterResult:
-        response = requests.request(
+    def _request(self, headers: dict | None) -> requests.Response:
+        return requests.request(
             method=self.request.method.value,
             url=self.request.url,
-            headers=self.request.headers,
+            headers=_headers_with_same_origin_referer(self.request.url, headers),
             verify=should_verify_http_ssl(),
         )
+
+    def _internal_convert(self, **kwargs: Any) -> DocumentConverterResult:
+        response = self._request(headers=self.request.headers)
         data_size = len(response.content)
         last_modified = _parse_last_modified_timestamp(response.headers)
         mimetype = _parse_mime_type_from_content_type(

--- a/packages/markitdown-api/tests/test_convert_http.py
+++ b/packages/markitdown-api/tests/test_convert_http.py
@@ -49,7 +49,10 @@ def test_http_converter_enables_ssl_verification_by_default(monkeypatch):
     assert request_call == {
         "method": "get",
         "url": "https://example.invalid/",
-        "headers": {"Accept": "text/html"},
+        "headers": {
+            "Accept": "text/html",
+            "Referer": "https://example.invalid/",
+        },
         "verify": True,
     }
 
@@ -62,7 +65,10 @@ def test_http_converter_enables_ssl_verification_when_configured_true(monkeypatc
     assert request_call == {
         "method": "get",
         "url": "https://example.invalid/",
-        "headers": {"Accept": "text/html"},
+        "headers": {
+            "Accept": "text/html",
+            "Referer": "https://example.invalid/",
+        },
         "verify": True,
     }
 
@@ -75,6 +81,98 @@ def test_http_converter_disables_ssl_verification_when_configured_false(monkeypa
     assert request_call == {
         "method": "get",
         "url": "https://example.invalid/",
-        "headers": {"Accept": "text/html"},
+        "headers": {
+            "Accept": "text/html",
+            "Referer": "https://example.invalid/",
+        },
         "verify": False,
     }
+
+
+def test_http_converter_adds_same_origin_referer_by_default(monkeypatch):
+    request_calls = []
+    url = "https://downloads.example.test/_Resources/images/document.pdf"
+
+    class FakeResponse:
+        content = b"%PDF-1.4\n"
+        headers = {"Content-Type": "application/pdf"}
+
+    class FakeMarkItDown:
+        def convert_response(self, response, stream_info, **kwargs):
+            return DocumentConverterResult(markdown="ok")
+
+    def fake_request(**kwargs):
+        request_calls.append(kwargs)
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "markitdown_api.api_converter.build_markitdown",
+        lambda request: FakeMarkItDown(),
+    )
+    monkeypatch.setattr("markitdown_api.convert_http.requests.request", fake_request)
+
+    result = HttpApiConverter(
+        ConvertHttpRequest(
+            url=url,
+            headers={
+                "user-agent": "Mozilla/5.0",
+            },
+        )
+    )._internal_convert()
+
+    assert result.markdown == "ok"
+    assert request_calls == [
+        {
+            "method": "get",
+            "url": url,
+            "headers": {
+                "user-agent": "Mozilla/5.0",
+                "Referer": "https://downloads.example.test/",
+            },
+            "verify": True,
+        },
+    ]
+
+
+def test_http_converter_preserves_explicit_referer(monkeypatch):
+    request_calls = []
+    url = "https://downloads.example.test/_Resources/images/document.pdf"
+
+    class FakeResponse:
+        content = b"%PDF-1.4\n"
+        headers = {"Content-Type": "application/pdf"}
+
+    class FakeMarkItDown:
+        def convert_response(self, response, stream_info, **kwargs):
+            return DocumentConverterResult(markdown="ok")
+
+    def fake_request(**kwargs):
+        request_calls.append(kwargs)
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "markitdown_api.api_converter.build_markitdown",
+        lambda request: FakeMarkItDown(),
+    )
+    monkeypatch.setattr("markitdown_api.convert_http.requests.request", fake_request)
+
+    result = HttpApiConverter(
+        ConvertHttpRequest(
+            url=url,
+            headers={
+                "referer": "https://example.com/custom",
+            },
+        )
+    )._internal_convert()
+
+    assert result.markdown == "ok"
+    assert request_calls == [
+        {
+            "method": "get",
+            "url": url,
+            "headers": {
+                "referer": "https://example.com/custom",
+            },
+            "verify": True,
+        },
+    ]


### PR DESCRIPTION
## Summary
- Add a same-origin `Referer` header by default for `/convert/http` outbound requests.
- Preserve caller-provided `Referer` or `referer` headers so explicit request behavior is not overwritten.
- Add regression coverage for default header injection, explicit referer preservation, and existing SSL verification behavior.

## Changes
- HTTP conversion now normalizes outgoing request headers before dispatch.
- Same-origin referer is derived from the request URL origin and root path.
- Tests use example-only URLs and verify the exact outgoing request payload.

## Testing
- `env -u OSS_ACCESS_KEY_ID -u OSS_ACCESS_KEY_SECRET -u OSS_SECRET_ACCESS_KEY -u OSS_SESSION_TOKEN -u OSS_BUCKET -u OSS_ENDPOINT -u OSS_IMAGE_KEY_PREFIX -u OSS_PUBLIC_BASE_URL -u OSS_OBJECT_ACL -u OSS_REGION PYTHONPATH=/Users/ahoo/work/mirror-github/markitdown/packages/markitdown-api/src:/Users/ahoo/work/mirror-github/markitdown/packages/markitdown/src uv run --no-project --with pytest --with requests --with fastapi --with python-multipart --with openai --with oss2 --with beautifulsoup4 --with markdownify --with 'magika~=0.6.1' --with charset-normalizer --with defusedxml pytest /Users/ahoo/work/mirror-github/markitdown/packages/markitdown-api/tests -q`
- `git diff --check HEAD~1 HEAD`
- Sensitive URL marker search returned no matches.

## Risk & Compatibility
- Low risk; no breaking changes identified from the diff.
- Existing callers that set `Referer` keep their current behavior.
- Callers without `Referer` will now send a same-origin referer, which may improve compatibility with static-file hosts that reject direct requests.

## Review Notes
- Please confirm the default referer behavior is acceptable for all `/convert/http` methods, not only GET.