### PR TITLE
fix(markdown): preserve empty anchor links

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -48,15 +48,23 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
     ):
         """Same as usual converter, but removes Javascript links and escapes URIs."""
         prefix, suffix, text = markdownify.chomp(text)  # type: ignore
+        raw_href = el.get("href")
+        href = raw_href
+        href = convert_relative_to_absolute_path(self.options["url"], href)
+        title = el.get("title")
+        title_used_as_text = False
         if not text:
-            return ""
+            if self._has_previous_duplicate_empty_anchor(el, raw_href, title):
+                return ""
+            text = title.strip() if title else ""
+            title_used_as_text = bool(text)
+            if not text and href:
+                text = href
+            if not text:
+                return ""
 
         if el.find_parent("pre") is not None:
             return text
-
-        href = el.get("href")
-        href = convert_relative_to_absolute_path(self.options["url"], href)
-        title = el.get("title")
 
         # Escape URIs and skip non-http or file schemes
         if href:
@@ -79,12 +87,38 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
             return "<%s>" % href
         if self.options["default_title"] and not title:
             title = href
-        title_part = ' "%s"' % title.replace('"', r"\"") if title else ""
+        title_part = (
+            ' "%s"' % title.replace('"', r"\"")
+            if title and not title_used_as_text
+            else ""
+        )
         return (
             "%s[%s](%s%s)%s" % (prefix, text, href, title_part, suffix)
             if href
             else text
         )
+
+    @staticmethod
+    def _has_previous_duplicate_empty_anchor(el: Any, href: Any, title: Any) -> bool:
+        if not href or not hasattr(el, "find_previous_siblings"):
+            return False
+
+        normalized_title = title.strip() if isinstance(title, str) else title
+        for sibling in el.find_previous_siblings("a"):
+            sibling_title = sibling.get("title")
+            normalized_sibling_title = (
+                sibling_title.strip()
+                if isinstance(sibling_title, str)
+                else sibling_title
+            )
+            if (
+                sibling.get("href") == href
+                and normalized_sibling_title == normalized_title
+                and not sibling.get_text(strip=True)
+            ):
+                return True
+
+        return False
 
     def convert_img(
         self,

--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -50,6 +50,9 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
     ):
         """Same as usual converter, but removes Javascript links and escapes URIs."""
         prefix, suffix, text = markdownify.chomp(text)  # type: ignore
+        if el.find_parent("pre") is not None:
+            return text
+
         raw_href = el.get("href")
         if self._has_unsupported_scheme(raw_href):
             return "" if not text else "%s%s%s" % (prefix, text, suffix)
@@ -63,13 +66,9 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
                 el, raw_href, title
             ):
                 return ""
-            text = self._fallback_link_text(title, href)
-            title_used_as_text = bool(text)
+            text, title_used_as_text = self._fallback_link_text(title, href)
             if not text:
                 return ""
-
-        if el.find_parent("pre") is not None:
-            return text
 
         # Escape URIs and skip non-http or file schemes
         if href:
@@ -115,12 +114,12 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
 
         return bool(scheme and scheme not in cls._SUPPORTED_LINK_SCHEMES)
 
-    def _fallback_link_text(self, title: Any, href: str) -> str:
+    def _fallback_link_text(self, title: Any, href: str) -> tuple[str, bool]:
         if isinstance(title, str) and title.strip():
             text = re.sub(r"\s+", " ", title.strip())
-            return self._escape_link_text(text)
+            return self._escape_link_text(text), True
 
-        return href
+        return self._escape_link_text(href), False
 
     def _escape_link_text(self, text: str) -> str:
         text = text.replace("\\", "\\\\")

--- a/packages/markitdown/src/markitdown/converters/_markdownify.py
+++ b/packages/markitdown/src/markitdown/converters/_markdownify.py
@@ -17,6 +17,8 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
     - Ensuring URIs are properly escaped, and do not conflict with Markdown syntax
     """
 
+    _SUPPORTED_LINK_SCHEMES = {"http", "https", "file"}
+
     def __init__(self, **options: Any):
         options["heading_style"] = options.get("heading_style", markdownify.ATX)
         options["keep_data_uris"] = options.get("keep_data_uris", False)
@@ -49,17 +51,20 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
         """Same as usual converter, but removes Javascript links and escapes URIs."""
         prefix, suffix, text = markdownify.chomp(text)  # type: ignore
         raw_href = el.get("href")
+        if self._has_unsupported_scheme(raw_href):
+            return "" if not text else "%s%s%s" % (prefix, text, suffix)
+
         href = raw_href
         href = convert_relative_to_absolute_path(self.options["url"], href)
         title = el.get("title")
         title_used_as_text = False
         if not text:
-            if self._has_previous_duplicate_empty_anchor(el, raw_href, title):
+            if not href or self._has_previous_duplicate_empty_anchor(
+                el, raw_href, title
+            ):
                 return ""
-            text = title.strip() if title else ""
+            text = self._fallback_link_text(title, href)
             title_used_as_text = bool(text)
-            if not text and href:
-                text = href
             if not text:
                 return ""
 
@@ -97,6 +102,35 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
             if href
             else text
         )
+
+    @classmethod
+    def _has_unsupported_scheme(cls, href: Any) -> bool:
+        if not isinstance(href, str) or not href:
+            return False
+
+        try:
+            scheme = urlparse(href).scheme.lower()
+        except ValueError:
+            return True
+
+        return bool(scheme and scheme not in cls._SUPPORTED_LINK_SCHEMES)
+
+    def _fallback_link_text(self, title: Any, href: str) -> str:
+        if isinstance(title, str) and title.strip():
+            text = re.sub(r"\s+", " ", title.strip())
+            return self._escape_link_text(text)
+
+        return href
+
+    def _escape_link_text(self, text: str) -> str:
+        text = text.replace("\\", "\\\\")
+        text = text.replace("[", r"\[")
+        text = text.replace("]", r"\]")
+        if self.options["escape_asterisks"]:
+            text = text.replace("*", r"\*")
+        if self.options["escape_underscores"]:
+            text = text.replace("_", r"\_")
+        return text
 
     @staticmethod
     def _has_previous_duplicate_empty_anchor(el: Any, href: Any, title: Any) -> bool:

--- a/packages/markitdown/tests/test_html_markdown.py
+++ b/packages/markitdown/tests/test_html_markdown.py
@@ -55,6 +55,78 @@ def test_duplicate_empty_anchors_with_same_href_are_emitted_once():
     assert result.markdown.count(expected_link) == 1
 
 
+def test_empty_anchor_without_href_does_not_emit_title_text():
+    html = """
+    <html>
+      <body>
+        <a id="section" title="Section title"></a>
+      </body>
+    </html>
+    """
+
+    result = MarkItDown().convert_stream(
+        BytesIO(html.encode("utf-8")),
+        stream_info=StreamInfo(
+            mimetype="text/html",
+            charset="utf-8",
+            url="https://example.com/products/",
+        ),
+    )
+
+    assert result.markdown == ""
+
+
+def test_empty_anchor_title_fallback_escapes_link_text():
+    html = """
+    <html>
+      <body>
+        <a
+          href="/download.pdf"
+          title="A ](https://bad.example)
+                 second line"
+        ></a>
+      </body>
+    </html>
+    """
+
+    result = MarkItDown().convert_stream(
+        BytesIO(html.encode("utf-8")),
+        stream_info=StreamInfo(
+            mimetype="text/html",
+            charset="utf-8",
+            url="https://example.com/products/",
+        ),
+    )
+
+    expected_link = (
+        r"[A \](https://bad.example) second line]" "(https://example.com/download.pdf)"
+    )
+
+    assert result.markdown == expected_link
+
+
+def test_empty_anchor_href_fallback_ignores_unsupported_schemes():
+    html = """
+    <html>
+      <body>
+        <a href="javascript:alert(1)"></a>
+        <a href="mailto:test@example.com" title="Email"></a>
+      </body>
+    </html>
+    """
+
+    result = MarkItDown().convert_stream(
+        BytesIO(html.encode("utf-8")),
+        stream_info=StreamInfo(
+            mimetype="text/html",
+            charset="utf-8",
+            url="https://example.com/products/",
+        ),
+    )
+
+    assert result.markdown == ""
+
+
 def test_html_path():
     result = (
         MarkItDown()

--- a/packages/markitdown/tests/test_html_markdown.py
+++ b/packages/markitdown/tests/test_html_markdown.py
@@ -105,6 +105,31 @@ def test_empty_anchor_title_fallback_escapes_link_text():
     assert result.markdown == expected_link
 
 
+def test_empty_anchor_href_fallback_escapes_link_text():
+    html = """
+    <html>
+      <body>
+        <a href="/a](bad).pdf"></a>
+      </body>
+    </html>
+    """
+
+    result = MarkItDown().convert_stream(
+        BytesIO(html.encode("utf-8")),
+        stream_info=StreamInfo(
+            mimetype="text/html",
+            charset="utf-8",
+            url="https://example.com/products/",
+        ),
+    )
+
+    expected_link = (
+        r"[https://example.com/a\](bad).pdf]" "(https://example.com/a%5D%28bad%29.pdf)"
+    )
+
+    assert result.markdown == expected_link
+
+
 def test_empty_anchor_href_fallback_ignores_unsupported_schemes():
     html = """
     <html>
@@ -125,6 +150,54 @@ def test_empty_anchor_href_fallback_ignores_unsupported_schemes():
     )
 
     assert result.markdown == ""
+
+
+def test_empty_anchor_in_pre_remains_empty():
+    html = """
+    <html>
+      <body>
+        <pre><a href="/download.pdf"></a></pre>
+      </body>
+    </html>
+    """
+
+    result = MarkItDown().convert_stream(
+        BytesIO(html.encode("utf-8")),
+        stream_info=StreamInfo(
+            mimetype="text/html",
+            charset="utf-8",
+            url="https://example.com/products/",
+        ),
+    )
+
+    assert result.markdown == ""
+
+
+def test_empty_anchor_href_fallback_preserves_default_title():
+    html = """
+    <html>
+      <body>
+        <a href="/download.pdf"></a>
+      </body>
+    </html>
+    """
+
+    result = MarkItDown().convert_stream(
+        BytesIO(html.encode("utf-8")),
+        stream_info=StreamInfo(
+            mimetype="text/html",
+            charset="utf-8",
+            url="https://example.com/products/",
+        ),
+        default_title=True,
+    )
+
+    expected_link = (
+        "[https://example.com/download.pdf]"
+        '(https://example.com/download.pdf "https://example.com/download.pdf")'
+    )
+
+    assert result.markdown == expected_link
 
 
 def test_html_path():

--- a/packages/markitdown/tests/test_html_markdown.py
+++ b/packages/markitdown/tests/test_html_markdown.py
@@ -1,4 +1,58 @@
-from markitdown import MarkItDown
+from io import BytesIO
+
+from markitdown import MarkItDown, StreamInfo
+
+
+def test_empty_anchor_uses_title_as_link_text():
+    html = """
+    <html>
+      <body>
+        <a
+          href="/downloads/product-guide.pdf"
+          title="Product guide"
+        ></a>
+      </body>
+    </html>
+    """
+
+    result = MarkItDown().convert_stream(
+        BytesIO(html.encode("utf-8")),
+        stream_info=StreamInfo(
+            mimetype="text/html",
+            charset="utf-8",
+            url="https://docs.example.test/products/example-item/",
+        ),
+    )
+
+    expected_link = (
+        "[Product guide]" "(https://docs.example.test/downloads/product-guide.pdf)"
+    )
+
+    assert expected_link in result.markdown
+
+
+def test_duplicate_empty_anchors_with_same_href_are_emitted_once():
+    html = """
+    <html>
+      <body>
+        <a href="/download.pdf" title="Download PDF"></a>
+        <a href="/download.pdf" title="Download PDF"></a>
+      </body>
+    </html>
+    """
+
+    result = MarkItDown().convert_stream(
+        BytesIO(html.encode("utf-8")),
+        stream_info=StreamInfo(
+            mimetype="text/html",
+            charset="utf-8",
+            url="https://example.com/products/",
+        ),
+    )
+
+    expected_link = "[Download PDF](https://example.com/download.pdf)"
+
+    assert result.markdown.count(expected_link) == 1
 
 
 def test_html_path():


### PR DESCRIPTION
## Summary
- Preserve links for empty HTML anchors by falling back to the anchor title, then href, as Markdown link text.
- Avoid emitting duplicate fallback links for repeated empty sibling anchors with the same href and title.
- Add synthetic regression tests for empty-anchor link preservation and duplicate empty-anchor handling.

## Changes
- Markdown conversion now resolves href before the empty-text guard so empty anchors with link metadata are retained.
- When title text is used as the fallback link text, it is not repeated as a Markdown title attribute.
- Tests use only synthetic example domains and paths.

## Testing
- `uv run --project packages/markitdown --with pytest pytest packages/markitdown/tests/test_html_markdown.py -q`
- `uv run --project packages/markitdown --extra all --with pytest pytest packages/markitdown/tests/test_module_vectors.py -q -k 'test_vector6 or test_vector7 or test_vector8'`
- `rg -n "wieland|gesis|0663|_Resources|NRG|产品手册" packages/markitdown/tests/test_html_markdown.py packages/markitdown/src/markitdown/converters/_markdownify.py || true`
- `git diff --check`

## Risk & Compatibility
- Low risk; behavior changes only for anchors whose converted text would previously be empty.
- Existing non-empty anchor rendering keeps the previous title and URL handling.

## Review Notes
- Review the duplicate-empty-anchor check to confirm it is narrow enough for repeated overlay/link-button markup.