### PR TITLE
ci(docker): harden deploy workflow triggers

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -22,6 +22,15 @@ on:
     branches:
       - 'dev'
   workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  PUBLISH_IMAGE: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+
+concurrency:
+  group: docker-deploy-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   api-docker-deploy:
     name: Push Docker image
@@ -34,21 +43,21 @@ jobs:
         uses: actions/checkout@master
 
       - name: Set up QEMU
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ env.PUBLISH_IMAGE == 'true' }}
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ env.PUBLISH_IMAGE == 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ env.PUBLISH_IMAGE == 'true' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -56,7 +65,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to AliyunCR
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ env.PUBLISH_IMAGE == 'true' }}
         uses: docker/login-action@v3
         with:
           registry: registry.cn-shanghai.aliyuncs.com
@@ -80,9 +89,9 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ env.PUBLISH_IMAGE == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           context: packages
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ env.PUBLISH_IMAGE == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=markitdown-api


### PR DESCRIPTION
## Summary
- Keep Docker image publishing limited to tag pushes and manual dispatches.
- Let scheduled and pull request runs build only `linux/amd64`, avoiding registry logins and image pushes.
- Enable the Node.js 24 JavaScript action runtime early and add workflow concurrency for duplicate PR runs.

## Changes
- Introduces a `PUBLISH_IMAGE` workflow env flag used by QEMU, registry login, platform selection, and `docker/build-push-action` push behavior.
- Scheduled runs now exercise the Docker build path without touching DockerHub, GHCR, or AliyunCR.
- Pull request runs continue to use the faster single-platform build-only path.

## Testing
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docker-deploy.yml'); puts 'yaml ok'"`
- `git diff --check`

## Risk & Compatibility
- Low risk for release behavior: tag pushes and manual dispatches still publish multi-arch images.
- Scheduled runs no longer publish or update the `dev` image tag; they now act as build validation only.
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` may expose action runtime compatibility issues earlier than GitHub's forced rollout.

## Review Notes
- Review the schedule behavior change carefully, since it intentionally stops nightly image pushes.
