### PR TITLE
fix(pdf): preserve two-column reading order

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -1136,6 +1136,26 @@ def _extract_tables_from_words(page: Any) -> list[list[list[str]]]:
     return [table_rows]
 
 
+def _join_pdf_page_chunks(
+    page_chunks: list[dict[str, Any]], pdfminer_pages: list[str] | None = None
+) -> str:
+    pdfminer_pages = pdfminer_pages or []
+    markdown_chunks: list[str] = []
+
+    for page_idx, page_chunk in enumerate(page_chunks):
+        text = page_chunk["text"]
+        if page_chunk["kind"] == "plain" and page_idx < len(pdfminer_pages):
+            pdfminer_text = pdfminer_pages[page_idx].strip()
+            if pdfminer_text:
+                text = pdfminer_text
+
+        if text:
+            markdown_chunks.append(text)
+        markdown_chunks.extend(page_chunk["images"])
+
+    return "\n\n".join(markdown_chunks).strip()
+
+
 class PdfConverter(DocumentConverter):
     """
     Converts PDFs to Markdown.
@@ -1236,37 +1256,27 @@ class PdfConverter(DocumentConverter):
 
                     page.close()  # Free cached page data immediately
 
-            # If no pages had form-style content, use pdfminer for
-            # the whole document (better text spacing for prose).
-            if form_page_count == 0 and multi_column_page_count == 0:
+            if form_page_count == 0:
                 pdf_bytes.seek(0)
-                markdown = pdfminer.high_level.extract_text(pdf_bytes)
-                if image_chunks:
-                    image_markdown = "\n\n".join(image_chunks)
-                    markdown = "\n\n".join(
-                        chunk for chunk in [markdown.strip(), image_markdown] if chunk
+                pdfminer_markdown = pdfminer.high_level.extract_text(pdf_bytes)
+
+                # With no layout-sensitive pages, keep the original whole-document
+                # pdfminer output because it generally spaces normal prose best.
+                if multi_column_page_count == 0:
+                    markdown = pdfminer_markdown
+                    if image_chunks:
+                        image_markdown = "\n\n".join(image_chunks)
+                        markdown = "\n\n".join(
+                            chunk
+                            for chunk in [markdown.strip(), image_markdown]
+                            if chunk
+                        )
+                else:
+                    markdown = _join_pdf_page_chunks(
+                        page_chunks, _split_pdfminer_pages(pdfminer_markdown)
                     )
             else:
-                markdown_chunks: list[str] = []
-                pdfminer_pages: list[str] = []
-                if form_page_count == 0 and multi_column_page_count > 0:
-                    pdf_bytes.seek(0)
-                    pdfminer_pages = _split_pdfminer_pages(
-                        pdfminer.high_level.extract_text(pdf_bytes)
-                    )
-
-                for page_idx, page_chunk in enumerate(page_chunks):
-                    text = page_chunk["text"]
-                    if page_chunk["kind"] == "plain" and page_idx < len(pdfminer_pages):
-                        pdfminer_text = pdfminer_pages[page_idx].strip()
-                        if pdfminer_text:
-                            text = pdfminer_text
-
-                    if text:
-                        markdown_chunks.append(text)
-                    markdown_chunks.extend(page_chunk["images"])
-
-                markdown = "\n\n".join(markdown_chunks).strip()
+                markdown = _join_pdf_page_chunks(page_chunks)
 
         except Exception:
             # Fallback if pdfplumber fails

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -552,6 +552,84 @@ def _join_word_text(words: list[dict[str, Any]]) -> str:
     return " ".join(text for word in words if (text := _word_text(word))).strip()
 
 
+def _split_pdfminer_pages(text: str) -> list[str]:
+    pages = text.split("\f")
+    if pages and not pages[-1].strip():
+        pages = pages[:-1]
+    return pages
+
+
+def _row_text_sides(row_words: list[dict[str, Any]], split_x: float) -> tuple[str, str]:
+    left_words = [
+        word for word in row_words if (_float_or_none(word.get("x0")) or 0.0) < split_x
+    ]
+    right_words = [
+        word for word in row_words if (_float_or_none(word.get("x0")) or 0.0) >= split_x
+    ]
+    return _join_word_text(left_words), _join_word_text(right_words)
+
+
+def _row_largest_gap(row_words: list[dict[str, Any]]) -> tuple[float, float | None]:
+    largest_gap = 0.0
+    largest_gap_midpoint: float | None = None
+
+    for previous_word, next_word in zip(row_words, row_words[1:]):
+        previous_x1 = _float_or_none(previous_word.get("x1"))
+        next_x0 = _float_or_none(next_word.get("x0"))
+        if previous_x1 is None or next_x0 is None:
+            continue
+
+        gap = next_x0 - previous_x1
+        if gap > largest_gap:
+            largest_gap = gap
+            largest_gap_midpoint = previous_x1 + (gap / 2)
+
+    return largest_gap, largest_gap_midpoint
+
+
+def _is_multi_column_prose_pair(left_text: str, right_text: str) -> bool:
+    if not left_text or not right_text:
+        return False
+
+    combined_length = len(left_text) + len(right_text)
+    return combined_length >= 50 and max(len(left_text), len(right_text)) >= 20
+
+
+def _row_is_footer_like(
+    row_words: list[dict[str, Any]], page_height: float, text: str
+) -> bool:
+    top_values = [
+        top
+        for word in row_words
+        if (top := _float_or_none(word.get("top"))) is not None
+    ]
+    return (
+        bool(top_values) and min(top_values) >= page_height * 0.90 and len(text) <= 40
+    )
+
+
+def _row_single_column_side(
+    row_words: list[dict[str, Any]], split_x: float, text: str, page_height: float
+) -> str | None:
+    if not text or _row_is_footer_like(row_words, page_height, text):
+        return None
+
+    x0_values = [
+        x0 for word in row_words if (x0 := _float_or_none(word.get("x0"))) is not None
+    ]
+    x1_values = [
+        x1 for word in row_words if (x1 := _float_or_none(word.get("x1"))) is not None
+    ]
+    if not x0_values or not x1_values:
+        return None
+
+    if max(x1_values) < split_x:
+        return "left"
+    if min(x0_values) >= split_x:
+        return "right"
+    return None
+
+
 def _extract_multi_column_text_from_words(page: Any) -> str | None:
     """
     Extract prose from simple multi-column pages in column reading order.
@@ -570,25 +648,22 @@ def _extract_multi_column_text_from_words(page: Any) -> str | None:
         return None
 
     page_width = _float_or_none(getattr(page, "width", None)) or 612.0
+    page_height = _float_or_none(getattr(page, "height", None)) or 792.0
     min_gutter = max(64.0, page_width * 0.10)
     split_candidates: list[float] = []
+    row_info: list[dict[str, Any]] = []
 
     for row_words in rows:
-        if len(row_words) < 2:
-            continue
-
-        largest_gap = 0.0
-        largest_gap_midpoint: float | None = None
-        for previous_word, next_word in zip(row_words, row_words[1:]):
-            previous_x1 = _float_or_none(previous_word.get("x1"))
-            next_x0 = _float_or_none(next_word.get("x0"))
-            if previous_x1 is None or next_x0 is None:
-                continue
-
-            gap = next_x0 - previous_x1
-            if gap > largest_gap:
-                largest_gap = gap
-                largest_gap_midpoint = previous_x1 + (gap / 2)
+        largest_gap, largest_gap_midpoint = _row_largest_gap(row_words)
+        text = _join_word_text(row_words)
+        row_info.append(
+            {
+                "words": row_words,
+                "text": text,
+                "largest_gap": largest_gap,
+                "largest_gap_midpoint": largest_gap_midpoint,
+            }
+        )
 
         if largest_gap >= min_gutter and largest_gap_midpoint is not None:
             split_candidates.append(largest_gap_midpoint)
@@ -607,34 +682,83 @@ def _extract_multi_column_text_from_words(page: Any) -> str | None:
     if len(consistent_candidates) < 3:
         return None
 
-    left_lines: list[str] = []
-    right_lines: list[str] = []
+    prose_candidate_count = 0
+    for info in row_info:
+        midpoint = info["largest_gap_midpoint"]
+        is_consistent_split = (
+            info["largest_gap"] >= min_gutter
+            and midpoint is not None
+            and abs(midpoint - split_x) <= max(36.0, page_width * 0.06)
+        )
+        left_text, right_text = _row_text_sides(info["words"], split_x)
+        is_prose_pair = is_consistent_split and _is_multi_column_prose_pair(
+            left_text, right_text
+        )
 
-    for row_words in rows:
-        left_words = [
-            word
-            for word in row_words
-            if (_float_or_none(word.get("x0")) or 0.0) < split_x
-        ]
-        right_words = [
-            word
-            for word in row_words
-            if (_float_or_none(word.get("x0")) or 0.0) >= split_x
-        ]
+        info["is_consistent_split"] = is_consistent_split
+        info["left_text"] = left_text
+        info["right_text"] = right_text
+        info["is_prose_pair"] = is_prose_pair
+        info["single_column_side"] = _row_single_column_side(
+            info["words"], split_x, info["text"], page_height
+        )
 
-        left_text = _join_word_text(left_words)
-        right_text = _join_word_text(right_words)
-        if left_text:
-            left_lines.append(left_text)
-        if right_text:
-            right_lines.append(right_text)
+        if is_prose_pair:
+            prose_candidate_count += 1
 
-    if len(left_lines) < 2 or len(right_lines) < 2:
+    if prose_candidate_count < 3:
         return None
 
-    return "\n\n".join(
-        block for block in ["\n".join(left_lines), "\n".join(right_lines)] if block
-    )
+    result_blocks: list[str] = []
+    idx = 0
+    while idx < len(row_info):
+        info = row_info[idx]
+        if not info["is_consistent_split"]:
+            if info["text"]:
+                result_blocks.append(info["text"])
+            idx += 1
+            continue
+
+        region: list[dict[str, Any]] = []
+        region_has_prose = False
+        while idx < len(row_info):
+            info = row_info[idx]
+            if info["is_consistent_split"]:
+                region.append(info)
+                region_has_prose = region_has_prose or info["is_prose_pair"]
+                idx += 1
+                continue
+
+            single_side = info["single_column_side"]
+            if region_has_prose and single_side is not None:
+                region.append(info)
+                idx += 1
+                continue
+
+            break
+
+        if not region_has_prose:
+            result_blocks.extend(info["text"] for info in region if info["text"])
+            continue
+
+        left_lines: list[str] = []
+        right_lines: list[str] = []
+        for region_info in region:
+            if region_info["is_consistent_split"]:
+                if region_info["left_text"]:
+                    left_lines.append(region_info["left_text"])
+                if region_info["right_text"]:
+                    right_lines.append(region_info["right_text"])
+            elif region_info["single_column_side"] == "left":
+                left_lines.append(region_info["text"])
+            elif region_info["single_column_side"] == "right":
+                right_lines.append(region_info["text"])
+
+        result_blocks.extend(
+            block for block in ["\n".join(left_lines), "\n".join(right_lines)] if block
+        )
+
+    return "\n\n".join(result_blocks)
 
 
 def _extract_form_content_from_words(page: Any) -> str | None:
@@ -1067,31 +1191,29 @@ class PdfConverter(DocumentConverter):
             # pages are collected separately. page.close() is called
             # after each page to free pdfplumber's cached objects and
             # keep memory usage constant regardless of page count.
-            markdown_chunks: list[str] = []
             image_chunks: list[str] = []
+            page_chunks: list[dict[str, Any]] = []
             form_page_count = 0
             multi_column_page_count = 0
-            plain_page_indices: list[int] = []
 
             with pdfplumber.open(pdf_bytes) as pdf:
                 for page_idx, page in enumerate(pdf.pages):
                     page_content = _extract_form_content_from_words(page)
 
                     if page_content is not None:
+                        chunk_kind = "form"
+                        text = page_content
                         form_page_count += 1
                         page_has_text_layer = bool(page_content.strip())
-                        if page_content.strip():
-                            markdown_chunks.append(page_content)
                     else:
+                        chunk_kind = "multi_column"
                         text = _extract_multi_column_text_from_words(page)
                         if text is not None:
                             multi_column_page_count += 1
                         else:
-                            plain_page_indices.append(page_idx)
+                            chunk_kind = "plain"
                             text = page.extract_text()
                         page_has_text_layer = bool((text or "").strip())
-                        if text and text.strip():
-                            markdown_chunks.append(text.strip())
 
                     page_image_chunks = (
                         _extract_pdf_image_markdown(
@@ -1102,8 +1224,15 @@ class PdfConverter(DocumentConverter):
                     )
 
                     if page_image_chunks:
-                        markdown_chunks.extend(page_image_chunks)
                         image_chunks.extend(page_image_chunks)
+
+                    page_chunks.append(
+                        {
+                            "kind": chunk_kind,
+                            "text": (text or "").strip(),
+                            "images": page_image_chunks,
+                        }
+                    )
 
                     page.close()  # Free cached page data immediately
 
@@ -1118,6 +1247,25 @@ class PdfConverter(DocumentConverter):
                         chunk for chunk in [markdown.strip(), image_markdown] if chunk
                     )
             else:
+                markdown_chunks: list[str] = []
+                pdfminer_pages: list[str] = []
+                if form_page_count == 0 and multi_column_page_count > 0:
+                    pdf_bytes.seek(0)
+                    pdfminer_pages = _split_pdfminer_pages(
+                        pdfminer.high_level.extract_text(pdf_bytes)
+                    )
+
+                for page_idx, page_chunk in enumerate(page_chunks):
+                    text = page_chunk["text"]
+                    if page_chunk["kind"] == "plain" and page_idx < len(pdfminer_pages):
+                        pdfminer_text = pdfminer_pages[page_idx].strip()
+                        if pdfminer_text:
+                            text = pdfminer_text
+
+                    if text:
+                        markdown_chunks.append(text)
+                    markdown_chunks.extend(page_chunk["images"])
+
                 markdown = "\n\n".join(markdown_chunks).strip()
 
         except Exception:

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -523,6 +523,120 @@ def _to_markdown_table(table: list[list[str]], include_separator: bool = True) -
     return "\n".join(md)
 
 
+def _group_words_by_y(
+    words: list[dict[str, Any]], y_tolerance: int = 5
+) -> list[list[dict[str, Any]]]:
+    rows_by_y: dict[float, list[dict[str, Any]]] = {}
+    for word in words:
+        top = _float_or_none(word.get("top"))
+        if top is None:
+            continue
+
+        y_key = round(top / y_tolerance) * y_tolerance
+        if y_key not in rows_by_y:
+            rows_by_y[y_key] = []
+        rows_by_y[y_key].append(word)
+
+    return [
+        sorted(row_words, key=lambda word: _float_or_none(word.get("x0")) or 0)
+        for _, row_words in sorted(rows_by_y.items())
+        if row_words
+    ]
+
+
+def _word_text(word: dict[str, Any]) -> str:
+    return str(word.get("text") or "").strip()
+
+
+def _join_word_text(words: list[dict[str, Any]]) -> str:
+    return " ".join(text for word in words if (text := _word_text(word))).strip()
+
+
+def _extract_multi_column_text_from_words(page: Any) -> str | None:
+    """
+    Extract prose from simple multi-column pages in column reading order.
+
+    pdfminer and pdfplumber's default extract_text() are usually better for
+    plain prose, but they can interleave independent columns that share similar
+    Y positions. This path is intentionally conservative: it only activates
+    when several rows show a consistent wide gutter between two text regions.
+    """
+    words = page.extract_words(keep_blank_chars=True, x_tolerance=3, y_tolerance=3)
+    if not words:
+        return None
+
+    rows = _group_words_by_y(words)
+    if len(rows) < 3:
+        return None
+
+    page_width = _float_or_none(getattr(page, "width", None)) or 612.0
+    min_gutter = max(64.0, page_width * 0.10)
+    split_candidates: list[float] = []
+
+    for row_words in rows:
+        if len(row_words) < 2:
+            continue
+
+        largest_gap = 0.0
+        largest_gap_midpoint: float | None = None
+        for previous_word, next_word in zip(row_words, row_words[1:]):
+            previous_x1 = _float_or_none(previous_word.get("x1"))
+            next_x0 = _float_or_none(next_word.get("x0"))
+            if previous_x1 is None or next_x0 is None:
+                continue
+
+            gap = next_x0 - previous_x1
+            if gap > largest_gap:
+                largest_gap = gap
+                largest_gap_midpoint = previous_x1 + (gap / 2)
+
+        if largest_gap >= min_gutter and largest_gap_midpoint is not None:
+            split_candidates.append(largest_gap_midpoint)
+
+    if len(split_candidates) < 3:
+        return None
+
+    split_candidates.sort()
+    split_x = split_candidates[len(split_candidates) // 2]
+
+    consistent_candidates = [
+        candidate
+        for candidate in split_candidates
+        if abs(candidate - split_x) <= max(36.0, page_width * 0.06)
+    ]
+    if len(consistent_candidates) < 3:
+        return None
+
+    left_lines: list[str] = []
+    right_lines: list[str] = []
+
+    for row_words in rows:
+        left_words = [
+            word
+            for word in row_words
+            if (_float_or_none(word.get("x0")) or 0.0) < split_x
+        ]
+        right_words = [
+            word
+            for word in row_words
+            if (_float_or_none(word.get("x0")) or 0.0) >= split_x
+        ]
+
+        left_text = _join_word_text(left_words)
+        right_text = _join_word_text(right_words)
+        if left_text:
+            left_lines.append(left_text)
+        if right_text:
+            right_lines.append(right_text)
+
+    if len(left_lines) < 2 or len(right_lines) < 2:
+        return None
+
+    return "\n\n".join(
+        block for block in ["\n".join(left_lines), "\n".join(right_lines)] if block
+    )
+
+
 def _extract_form_content_from_words(page: Any) -> str | None:
     """
     Extract form-style content from a PDF page by analyzing word positions.
@@ -956,6 +1070,7 @@ class PdfConverter(DocumentConverter):
             markdown_chunks: list[str] = []
             image_chunks: list[str] = []
             form_page_count = 0
+            multi_column_page_count = 0
             plain_page_indices: list[int] = []
 
             with pdfplumber.open(pdf_bytes) as pdf:
@@ -968,8 +1083,12 @@ class PdfConverter(DocumentConverter):
                         if page_content.strip():
                             markdown_chunks.append(page_content)
                     else:
-                        plain_page_indices.append(page_idx)
-                        text = page.extract_text()
+                        text = _extract_multi_column_text_from_words(page)
+                        if text is not None:
+                            multi_column_page_count += 1
+                        else:
+                            plain_page_indices.append(page_idx)
+                            text = page.extract_text()
                         page_has_text_layer = bool((text or "").strip())
                         if text and text.strip():
                             markdown_chunks.append(text.strip())
@@ -990,7 +1109,7 @@ class PdfConverter(DocumentConverter):
 
             # If no pages had form-style content, use pdfminer for
             # the whole document (better text spacing for prose).
-            if form_page_count == 0:
+            if form_page_count == 0 and multi_column_page_count == 0:
                 pdf_bytes.seek(0)
                 markdown = pdfminer.high_level.extract_text(pdf_bytes)
                 if image_chunks:

--- a/packages/markitdown/tests/test_pdf_memory.py
+++ b/packages/markitdown/tests/test_pdf_memory.py
@@ -82,18 +82,94 @@ def _make_two_column_page():
     page.height = 792
     page.close = MagicMock()
     page.extract_words.return_value = [
-        {"text": "Left heading", "x0": 60, "x1": 140, "top": 80, "bottom": 92},
+        {
+            "text": "Document overview title",
+            "x0": 60,
+            "x1": 260,
+            "top": 50,
+            "bottom": 62,
+        },
+        {"text": "Left heading", "x0": 60, "x1": 245, "top": 80, "bottom": 92},
         {"text": "Right heading", "x0": 340, "x1": 430, "top": 80, "bottom": 92},
-        {"text": "Left body one", "x0": 60, "x1": 170, "top": 110, "bottom": 122},
-        {"text": "Right body one", "x0": 340, "x1": 460, "top": 110, "bottom": 122},
-        {"text": "Left body two", "x0": 60, "x1": 170, "top": 130, "bottom": 142},
-        {"text": "Right body two", "x0": 340, "x1": 460, "top": 130, "bottom": 142},
+        {
+            "text": "Left body line one has enough prose content",
+            "x0": 60,
+            "x1": 245,
+            "top": 110,
+            "bottom": 122,
+        },
+        {
+            "text": "Right body line one has enough prose content",
+            "x0": 340,
+            "x1": 535,
+            "top": 110,
+            "bottom": 122,
+        },
+        {
+            "text": "Left body line two keeps the left narrative together",
+            "x0": 60,
+            "x1": 270,
+            "top": 130,
+            "bottom": 142,
+        },
+        {
+            "text": "Right body line two keeps the right narrative together",
+            "x0": 340,
+            "x1": 550,
+            "top": 130,
+            "bottom": 142,
+        },
+        {
+            "text": "Left body line three continues below the matching row",
+            "x0": 60,
+            "x1": 275,
+            "top": 150,
+            "bottom": 162,
+        },
+        {
+            "text": "Right body line three continues below the matching row",
+            "x0": 340,
+            "x1": 555,
+            "top": 150,
+            "bottom": 162,
+        },
+        {
+            "text": "Document footer text",
+            "x0": 60,
+            "x1": 190,
+            "top": 740,
+            "bottom": 752,
+        },
     ]
     page.extract_text.return_value = (
+        "Document overview title\n"
         "Left heading Right heading\n"
-        "Left body one Right body one\n"
-        "Left body two Right body two"
+        "Left body line one has enough prose content "
+        "Right body line one has enough prose content\n"
+        "Left body line two keeps the left narrative together "
+        "Right body line two keeps the right narrative together\n"
+        "Left body line three continues below the matching row "
+        "Right body line three continues below the matching row\n"
+        "Document footer text"
     )
+    return page
+
+
+def _make_two_column_table_page():
+    """Create a mock page with a two-column key/value table."""
+    page = MagicMock()
+    page.width = 612
+    page.height = 792
+    page.close = MagicMock()
+    page.extract_words.return_value = [
+        {"text": "Name", "x0": 60, "x1": 100, "top": 80, "bottom": 92},
+        {"text": "Alice", "x0": 340, "x1": 390, "top": 80, "bottom": 92},
+        {"text": "Date", "x0": 60, "x1": 95, "top": 110, "bottom": 122},
+        {"text": "2026", "x0": 340, "x1": 385, "top": 110, "bottom": 122},
+        {"text": "Owner", "x0": 60, "x1": 112, "top": 130, "bottom": 142},
+        {"text": "Bob", "x0": 340, "x1": 370, "top": 130, "bottom": 142},
+    ]
+    page.extract_text.return_value = "Name Alice\nDate 2026\nOwner Bob"
     return page
 
 
@@ -240,10 +316,53 @@ class TestPdfMemoryOptimization:
             "markitdown.converters._pdf_converter.pdfminer"
         ) as mock_pdfminer:
             mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = page.extract_text()
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+            )
+
+        assert result.text_content is not None
+        assert "Document overview title" in result.text_content
+        assert (
+            "Left heading\n"
+            "Left body line one has enough prose content\n"
+            "Left body line two keeps the left narrative together\n"
+            "Left body line three continues below the matching row"
+        ) in result.text_content
+        assert (
+            "Right heading\n"
+            "Right body line one has enough prose content\n"
+            "Right body line two keeps the right narrative together\n"
+            "Right body line three continues below the matching row"
+        ) in result.text_content
+        assert (
+            "Left body line one has enough prose content "
+            "Right body line one has enough prose content"
+        ) not in result.text_content
+        assert result.text_content.rfind(
+            "Document footer text"
+        ) > result.text_content.rfind(
+            "Right body line three continues below the matching row"
+        )
+
+    def test_two_column_key_value_pdf_falls_back_to_pdfminer(self):
+        """Two-column key/value rows should preserve row associations."""
+        page = _make_two_column_table_page()
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
             mock_pdfminer.high_level.extract_text.return_value = (
-                "Left heading Right heading\n"
-                "Left body one Right body one\n"
-                "Left body two Right body two"
+                "Name Alice\nDate 2026\nOwner Bob"
             )
 
             md = MarkItDown()
@@ -256,10 +375,51 @@ class TestPdfMemoryOptimization:
             )
 
         assert result.text_content is not None
-        assert "Left heading\nLeft body one\nLeft body two" in result.text_content
-        assert "Right heading\nRight body one\nRight body two" in result.text_content
-        assert "Left body one Right body one" not in result.text_content
-        assert not mock_pdfminer.high_level.extract_text.called
+        assert mock_pdfminer.high_level.extract_text.called
+        assert "Name Alice\nDate 2026\nOwner Bob" in result.text_content
+        assert "Name\nDate\nOwner\n\nAlice" not in result.text_content
+
+    def test_plain_pages_use_pdfminer_when_document_has_multicolumn_page(self):
+        """Only detected multi-column pages should replace pdfminer output."""
+        plain_before = _make_plain_page()
+        plain_before.extract_text.return_value = "page extract text before"
+        plain_after = _make_plain_page()
+        plain_after.extract_text.return_value = "page extract text after"
+        multi_column = _make_two_column_page()
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open(
+                [plain_before, multi_column, plain_after]
+            )
+            mock_pdfminer.high_level.extract_text.return_value = (
+                "pdfminer text before\f"
+                "interleaved multi-column fallback\f"
+                "pdfminer text after\f"
+            )
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+            )
+
+        assert result.text_content is not None
+        assert "pdfminer text before" in result.text_content
+        assert "pdfminer text after" in result.text_content
+        assert "page extract text before" not in result.text_content
+        assert "page extract text after" not in result.text_content
+        assert "interleaved multi-column fallback" not in result.text_content
+        assert (
+            "Left heading\nLeft body line one has enough prose content"
+            in result.text_content
+        )
 
     def test_plain_text_pdf_still_closes_all_pages(self):
         """Even for plain-text PDFs, page.close() must be called on every page."""

--- a/packages/markitdown/tests/test_pdf_memory.py
+++ b/packages/markitdown/tests/test_pdf_memory.py
@@ -75,6 +75,28 @@ def _make_plain_page():
     return page
 
 
+def _make_two_column_page():
+    """Create a mock plain-text page with two prose columns."""
+    page = MagicMock()
+    page.width = 612
+    page.height = 792
+    page.close = MagicMock()
+    page.extract_words.return_value = [
+        {"text": "Left heading", "x0": 60, "x1": 140, "top": 80, "bottom": 92},
+        {"text": "Right heading", "x0": 340, "x1": 430, "top": 80, "bottom": 92},
+        {"text": "Left body one", "x0": 60, "x1": 170, "top": 110, "bottom": 122},
+        {"text": "Right body one", "x0": 340, "x1": 460, "top": 110, "bottom": 122},
+        {"text": "Left body two", "x0": 60, "x1": 170, "top": 130, "bottom": 142},
+        {"text": "Right body two", "x0": 340, "x1": 460, "top": 130, "bottom": 142},
+    ]
+    page.extract_text.return_value = (
+        "Left heading Right heading\n"
+        "Left body one Right body one\n"
+        "Left body two Right body two"
+    )
+    return page
+
+
 class _FakePdfImageStream:
     def __init__(self, data: bytes, pdf_filter: str, **attrs):
         self.attrs = {"Filter": pdf_filter, **attrs}
@@ -207,6 +229,37 @@ class TestPdfMemoryOptimization:
             "plain-text PDFs should fall back to pdfminer"
         )
         assert result.text_content is not None
+
+    def test_two_column_plain_text_pdf_preserves_column_reading_order(self):
+        """Two-column prose should not be interleaved row by row."""
+        page = _make_two_column_page()
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = (
+                "Left heading Right heading\n"
+                "Left body one Right body one\n"
+                "Left body two Right body two"
+            )
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+            )
+
+        assert result.text_content is not None
+        assert "Left heading\nLeft body one\nLeft body two" in result.text_content
+        assert "Right heading\nRight body one\nRight body two" in result.text_content
+        assert "Left body one Right body one" not in result.text_content
+        assert not mock_pdfminer.high_level.extract_text.called
 
     def test_plain_text_pdf_still_closes_all_pages(self):
         """Even for plain-text PDFs, page.close() must be called on every page."""


### PR DESCRIPTION
## Summary
- Add a conservative multi-column prose extractor for PDF pages with a stable wide gutter.
- Preserve normal plain-text behavior by keeping the whole-document pdfminer fallback when no form or multi-column pages are detected.
- Add a synthetic regression test that verifies two-column prose is emitted by column instead of interleaving same-row content.

## Changes
- PDF conversion now checks non-form pages for simple two-column layouts before falling back to `page.extract_text()`.
- Multi-column detection is based on repeated, consistent row gaps and emits the left column block before the right column block.
- Plain single-column PDFs still use the existing pdfminer whole-document fallback.

## Testing
- `uv run --project packages/markitdown --extra all --with pytest pytest packages/markitdown/tests/test_pdf_memory.py packages/markitdown/tests/test_pdf_masterformat.py packages/markitdown/tests/test_pdf_tables.py -q` (`43 passed, 2 skipped`)
- `git diff --check`
- Commit hook: `black` passed.

## Risk & Compatibility
- Low risk; no breaking changes identified from the diff.
- The new path only activates when multiple rows show a consistent large gutter, so ordinary prose PDFs retain the existing pdfminer fallback.
- The change affects PDF text extraction behavior for simple multi-column pages.

## Review Notes
- Please pay special attention to the multi-column activation threshold and whether it is conservative enough for mixed prose/table PDFs.