### PR TITLE
feat(api): configure keep data uris default via env

### DIFF
--- a/packages/markitdown-api/src/markitdown_api/_env.py
+++ b/packages/markitdown-api/src/markitdown_api/_env.py
@@ -1,0 +1,16 @@
+import os
+
+
+FALSE_VALUES = {"0", "false", "no", "off"}
+KEEP_DATA_URIS_ENV = "MARKITDOWN_API_KEEP_DATA_URIS"
+
+
+def env_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in FALSE_VALUES
+
+
+def default_keep_data_uris() -> bool:
+    return env_bool(KEEP_DATA_URIS_ENV, False)

--- a/packages/markitdown-api/src/markitdown_api/api_types.py
+++ b/packages/markitdown-api/src/markitdown_api/api_types.py
@@ -3,6 +3,7 @@ from typing import List
 from pydantic import BaseModel, Field
 from starlette.responses import Response
 from markitdown._llm_utils import get_llm_prompt
+from markitdown_api._env import default_keep_data_uris
 
 
 class LlmOptions(BaseModel):
@@ -52,7 +53,7 @@ class ConvertRequest(BaseModel):
     )
     rag: RagOptions = Field(default_factory=RagOptions, description="RAG options")
     keep_data_uris: bool = Field(
-        default=False,
+        default_factory=default_keep_data_uris,
         description="If keep_data_uris is True, use base64 encoding for images",
     )
     strict: bool = Field(

--- a/packages/markitdown-api/src/markitdown_api/commons.py
+++ b/packages/markitdown-api/src/markitdown_api/commons.py
@@ -4,10 +4,10 @@ from typing import Optional
 from openai import OpenAI
 
 from markitdown import MarkItDown
+from markitdown_api._env import env_bool
 from markitdown_api.api_types import LlmOptions, ConvertRequest
 
 HTTP_VERIFY_SSL_ENV = "MARKITDOWN_API_HTTP_VERIFY_SSL"
-FALSE_VALUES = {"0", "false", "no", "off"}
 
 
 def is_blank(s: str) -> bool:
@@ -21,10 +21,7 @@ def blank_then_none(s: str) -> str | None:
 
 
 def should_verify_http_ssl() -> bool:
-    value = os.environ.get(HTTP_VERIFY_SSL_ENV)
-    if value is None:
-        return True
-    return value.strip().lower() not in FALSE_VALUES
+    return env_bool(HTTP_VERIFY_SSL_ENV, True)
 
 
 def _build_markitdown(llm_options: Optional[LlmOptions] = None) -> MarkItDown:

--- a/packages/markitdown-api/src/markitdown_api/convert_file.py
+++ b/packages/markitdown-api/src/markitdown_api/convert_file.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, UploadFile, File, Form
 
 from markitdown import StreamInfo, DocumentConverterResult
 from markitdown_api._utils import _parse_mime_type_from_content_type
+from markitdown_api._env import default_keep_data_uris
 from markitdown_api.api_converter import ApiConverter
 from markitdown_api.api_types import (
     LlmOptions,
@@ -52,6 +53,10 @@ def _parse_rag_heading_keywords(value: str) -> list[str]:
     return [keyword.strip() for keyword in normalized.split(",") if keyword.strip()]
 
 
+def _resolve_keep_data_uris(value: bool | None) -> bool:
+    return default_keep_data_uris() if value is None else value
+
+
 @router.post(path="", response_model=ConvertResponse)
 async def convert_file(
     file: Annotated[UploadFile, File()],
@@ -59,14 +64,14 @@ async def convert_file(
     openai_api_key: Annotated[str, Form()] = "",
     llm_model: Annotated[str, Form()] = "",
     llm_prompt: Annotated[str, Form()] = "",
-    keep_data_uris: Annotated[bool, Form()] = False,
+    keep_data_uris: Annotated[bool | None, Form()] = None,
     rag_clean: Annotated[bool, Form()] = True,
     rag_heading_keywords: Annotated[str, Form()] = "",
 ):
     return FileApiConverter(
         ConvertFileRequest(
             file=file,
-            keep_data_uris=keep_data_uris,
+            keep_data_uris=_resolve_keep_data_uris(keep_data_uris),
             rag=RagOptions(
                 enabled=rag_clean,
                 heading_keywords=_parse_rag_heading_keywords(rag_heading_keywords),
@@ -88,7 +93,7 @@ async def convert_file_markdown(
     openai_api_key: Annotated[str, Form()] = "",
     llm_model: Annotated[str, Form()] = "",
     llm_prompt: Annotated[str, Form()] = "",
-    keep_data_uris: Annotated[bool, Form()] = False,
+    keep_data_uris: Annotated[bool | None, Form()] = None,
     rag_clean: Annotated[bool, Form()] = True,
     rag_heading_keywords: Annotated[str, Form()] = "",
 ):
@@ -96,7 +101,7 @@ async def convert_file_markdown(
         FileApiConverter(
             ConvertFileRequest(
                 file=file,
-                keep_data_uris=keep_data_uris,
+                keep_data_uris=_resolve_keep_data_uris(keep_data_uris),
                 rag=RagOptions(
                     enabled=rag_clean,
                     heading_keywords=_parse_rag_heading_keywords(rag_heading_keywords),

--- a/packages/markitdown-api/tests/test_oss_image_upload.py
+++ b/packages/markitdown-api/tests/test_oss_image_upload.py
@@ -2,9 +2,12 @@ import base64
 import hashlib
 import inspect
 import logging
+import asyncio
+from io import BytesIO
 from datetime import datetime, timezone
 
 import pytest
+from fastapi import UploadFile
 
 from markitdown import DocumentConverterResult
 from markitdown_api.api_converter import ApiConverter
@@ -15,6 +18,8 @@ from markitdown_api.oss_image_upload import (
     _credentials_provider_from_environment,
     replace_data_images_with_oss_urls,
 )
+
+KEEP_DATA_URIS_ENV = "MARKITDOWN_API_KEEP_DATA_URIS"
 
 
 def test_replace_data_images_uploads_and_rewrites_markdown_image():
@@ -97,7 +102,8 @@ def test_replace_data_images_keeps_data_uri_when_single_upload_fails():
     )
 
 
-def test_oss_image_uploader_uses_stable_hash_key_and_public_url():
+def test_oss_image_uploader_uses_stable_hash_key_and_public_url(monkeypatch):
+    monkeypatch.delenv("OSS_PUBLIC_BASE_URL", raising=False)
     image_bytes = b"fake-png-bytes"
     digest = hashlib.sha256(image_bytes).hexdigest()
     fixed_now = datetime(2026, 6, 1, tzinfo=timezone.utc)
@@ -173,19 +179,87 @@ def test_oss_credentials_provider_missing_secret_mentions_both_supported_names(
         _credentials_provider_from_environment(object())
 
 
-def test_convert_request_disables_keep_data_uris_by_default():
+def test_convert_request_disables_keep_data_uris_by_default(monkeypatch):
+    monkeypatch.delenv(KEEP_DATA_URIS_ENV, raising=False)
+
     assert ConvertRequest().keep_data_uris is False
 
 
-def test_file_upload_endpoints_disable_keep_data_uris_by_default():
-    assert inspect.signature(convert_file).parameters["keep_data_uris"].default is False
+def test_convert_request_uses_keep_data_uris_env_default(monkeypatch):
+    monkeypatch.setenv(KEEP_DATA_URIS_ENV, "true")
+
+    assert ConvertRequest().keep_data_uris is True
+
+
+def test_convert_request_explicit_false_overrides_keep_data_uris_env(monkeypatch):
+    monkeypatch.setenv(KEEP_DATA_URIS_ENV, "true")
+
+    assert ConvertRequest(keep_data_uris=False).keep_data_uris is False
+
+
+def test_file_upload_endpoints_allow_keep_data_uris_env_default():
+    assert inspect.signature(convert_file).parameters["keep_data_uris"].default is None
     assert (
         inspect.signature(convert_file_markdown).parameters["keep_data_uris"].default
-        is False
+        is None
     )
 
 
+def test_file_upload_endpoint_uses_keep_data_uris_env_default(monkeypatch):
+    monkeypatch.setenv(KEEP_DATA_URIS_ENV, "true")
+    seen_keep_data_uris = []
+
+    class StubFileApiConverter:
+        def __init__(self, request):
+            seen_keep_data_uris.append(request.keep_data_uris)
+
+        def convert(self):
+            return "ok"
+
+    monkeypatch.setattr(
+        "markitdown_api.convert_file.FileApiConverter",
+        StubFileApiConverter,
+    )
+
+    response = asyncio.run(
+        convert_file(file=UploadFile(filename="test.txt", file=BytesIO(b"text")))
+    )
+
+    assert response == "ok"
+    assert seen_keep_data_uris == [True]
+
+
+def test_file_upload_endpoint_explicit_false_overrides_keep_data_uris_env(
+    monkeypatch,
+):
+    monkeypatch.setenv(KEEP_DATA_URIS_ENV, "true")
+    seen_keep_data_uris = []
+
+    class StubFileApiConverter:
+        def __init__(self, request):
+            seen_keep_data_uris.append(request.keep_data_uris)
+
+        def convert(self):
+            return "ok"
+
+    monkeypatch.setattr(
+        "markitdown_api.convert_file.FileApiConverter",
+        StubFileApiConverter,
+    )
+
+    response = asyncio.run(
+        convert_file(
+            file=UploadFile(filename="test.txt", file=BytesIO(b"text")),
+            keep_data_uris=False,
+        )
+    )
+
+    assert response == "ok"
+    assert seen_keep_data_uris == [False]
+
+
 def test_api_converter_rewrites_embedded_images_after_conversion(monkeypatch):
+    monkeypatch.delenv(KEEP_DATA_URIS_ENV, raising=False)
     image_bytes = b"fake-png-bytes"
     encoded = base64.b64encode(image_bytes).decode("ascii")
     markdown = f"![chart](data:image/png;base64,{encoded})"


### PR DESCRIPTION
## Summary
- Add MARKITDOWN_API_KEEP_DATA_URIS to control the API default for keeping data URIs.
- Preserve explicit request values so callers can still override the environment default.
- Share boolean environment parsing with existing API SSL verification configuration.
- Extend tests for JSON request defaults, file upload defaults, and explicit override behavior.

## Changes
- API configuration: added shared boolean environment helpers with MARKITDOWN_API_KEEP_DATA_URIS support.
- Request models: ConvertRequest now reads keep_data_uris from the environment when the field is omitted.
- File upload endpoints: multipart keep_data_uris defaults to the environment only when the form field is not provided.
- Tests: added coverage for env defaults, explicit false overrides, and isolated OSS public URL behavior from local environment variables.

## Testing
- `PYTHONPATH=/Users/ahoo/.codex/worktrees/5a78/markitdown/packages/markitdown-api/src uv run --project packages/markitdown --extra all --with pytest --with fastapi --with openai --with oss2 --with python-multipart python -m pytest packages/markitdown-api/tests -q`
- `git diff --check origin/dev..HEAD`

## Risk & Compatibility
- Low risk; explicit API request values continue to override the environment default.
- Runtime behavior changes only when MARKITDOWN_API_KEEP_DATA_URIS is set in the deployment environment.

## Review Notes
- Please verify the multipart/form-data default handling, where omitted keep_data_uris now differs from an explicit false value.