### PR TITLE
fix(pdf): preserve form table image layout

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -11,6 +11,8 @@ from .._exceptions import MissingDependencyException, MISSING_DEPENDENCY_MESSAGE
 
 # Pattern for MasterFormat-style partial numbering (e.g., ".1", ".2", ".10")
 PARTIAL_NUMBERING_PATTERN = re.compile(r"^\.\d+$")
+COMPACT_TABLE_CELL_LENGTH = 120
+MARKDOWN_IMAGE_PATTERN = re.compile(r"!\[[^\]]*\]\(")
 
 
 def _merge_partial_numbering_lines(text: str) -> str:
@@ -459,10 +461,10 @@ def _pdf_image_to_data_uri(image: Any) -> str | None:
     return f"data:{mimetype};base64,{payload}"
 
 
-def _extract_pdf_image_markdown(
+def _extract_pdf_image_entries(
     page: Any, page_number: int, page_has_text_layer: bool | None = None
-) -> list[str]:
-    markdown_images: list[str] = []
+) -> list[dict[str, Any]]:
+    image_entries: list[dict[str, Any]] = []
     if page_has_text_layer is None:
         try:
             page_has_text_layer = bool((page.extract_text() or "").strip())
@@ -477,17 +479,64 @@ def _extract_pdf_image_markdown(
         if data_uri is None:
             continue
         alt_text = f"PDF page {page_number} image {image_number}"
-        markdown_images.append(f"![{alt_text}]({data_uri})")
-    return markdown_images
+        image_entries.append(
+            {
+                "markdown": f"![{alt_text}]({data_uri})",
+                "x0": _float_or_none(image.get("x0")),
+                "x1": _float_or_none(image.get("x1")),
+                "top": _float_or_none(image.get("top")),
+                "bottom": _float_or_none(image.get("bottom")),
+                "used": False,
+            }
+        )
+    return image_entries
 
 
-def _to_markdown_table(table: list[list[str]], include_separator: bool = True) -> str:
+def _extract_pdf_image_markdown(
+    page: Any, page_number: int, page_has_text_layer: bool | None = None
+) -> list[str]:
+    return [
+        image_entry["markdown"]
+        for image_entry in _extract_pdf_image_entries(
+            page, page_number, page_has_text_layer
+        )
+    ]
+
+
+def _table_needs_compact_format(table: list[list[str]]) -> bool:
+    for row in table:
+        for cell in row:
+            cell_text = str(cell or "")
+            if len(cell_text) > COMPACT_TABLE_CELL_LENGTH:
+                return True
+            if "data:image/" in cell_text or MARKDOWN_IMAGE_PATTERN.search(cell_text):
+                return True
+    return False
+
+
+def _trim_empty_trailing_columns(table: list[list[str]]) -> list[list[str]]:
+    if not table:
+        return table
+
+    num_cols = max(len(row) for row in table)
+    normalized = [row + [""] * (num_cols - len(row)) for row in table]
+
+    while num_cols > 1 and all(not row[num_cols - 1].strip() for row in normalized):
+        num_cols -= 1
+
+    return [row[:num_cols] for row in normalized]
+
+
+def _to_markdown_table(
+    table: list[list[str]], include_separator: bool = True, *, pad_cells: bool = False
+) -> str:
     """Convert a 2D list (rows/columns) into a nicely aligned Markdown table.
 
     Args:
         table: 2D list of cell values
         include_separator: If True, include header separator row (standard markdown).
                           If False, output simple pipe-separated rows.
+        pad_cells: If True, include spaces around pipe separators.
     """
     if not table:
         return ""
@@ -501,20 +550,59 @@ def _to_markdown_table(table: list[list[str]], include_separator: bool = True) -
     if not table:
         return ""
 
+    table = _trim_empty_trailing_columns(table)
+    num_cols = max(len(row) for row in table)
+    compact_format = _table_needs_compact_format(table)
+
+    def fmt_compact_row(row: list[str]) -> str:
+        if pad_cells:
+            return "| " + " | ".join(str(cell) for cell in row) + " |"
+        return "|" + "|".join(str(cell) for cell in row) + "|"
+
+    def fmt_compact_separator() -> str:
+        if pad_cells:
+            return "| " + " | ".join("---" for _ in range(num_cols)) + " |"
+        return "|" + "|".join("---" for _ in range(num_cols)) + "|"
+
+    if compact_format:
+        if include_separator:
+            header, *rows = table
+            md = [fmt_compact_row(header), fmt_compact_separator()]
+            md.extend(fmt_compact_row(row) for row in rows)
+        else:
+            md = [fmt_compact_row(row) for row in table]
+        return "\n".join(md)
+
     # Column widths
-    col_widths = [max(len(str(cell)) for cell in col) for col in zip(*table)]
+    col_widths = [
+        max(3, max(len(str(row[col_idx])) for row in table))
+        for col_idx in range(num_cols)
+    ]
 
     def fmt_row(row: list[str]) -> str:
+        if pad_cells:
+            return (
+                "| "
+                + " | ".join(
+                    str(cell).ljust(col_widths[i]) for i, cell in enumerate(row)
+                )
+                + " |"
+            )
         return (
             "|"
             + "|".join(str(cell).ljust(width) for cell, width in zip(row, col_widths))
             + "|"
         )
 
+    def fmt_separator() -> str:
+        if pad_cells:
+            return "| " + " | ".join("-" * w for w in col_widths) + " |"
+        return "|" + "|".join("-" * w for w in col_widths) + "|"
+
     if include_separator:
         header, *rows = table
         md = [fmt_row(header)]
-        md.append("|" + "|".join("-" * w for w in col_widths) + "|")
+        md.append(fmt_separator())
         for row in rows:
             md.append(fmt_row(row))
     else:
@@ -541,6 +629,63 @@ def _group_words_by_y(
         sorted(row_words, key=lambda word: _float_or_none(word.get("x0")) or 0)
         for _, row_words in sorted(rows_by_y.items())
         if row_words
+    ]
+
+
+def _group_words_by_visual_row(
+    words: list[dict[str, Any]], y_tolerance: int = 5
+) -> list[list[dict[str, Any]]]:
+    rows: list[dict[str, Any]] = []
+    sorted_words = sorted(
+        words,
+        key=lambda word: (
+            _float_or_none(word.get("top")) or 0,
+            _float_or_none(word.get("x0")) or 0,
+        ),
+    )
+
+    for word in sorted_words:
+        top = _float_or_none(word.get("top"))
+        bottom = _float_or_none(word.get("bottom"))
+        if top is None or bottom is None:
+            continue
+
+        center = (top + bottom) / 2
+        best_row = None
+        best_score = float("-inf")
+
+        for row in reversed(rows):
+            if top - row["bottom"] > y_tolerance and center > row["center"]:
+                break
+
+            center_delta = abs(center - row["center"])
+
+            if center_delta <= y_tolerance:
+                score = -center_delta
+                if score > best_score:
+                    best_score = score
+                    best_row = row
+
+        if best_row is None:
+            rows.append(
+                {
+                    "top": top,
+                    "bottom": bottom,
+                    "center": center,
+                    "words": [word],
+                }
+            )
+            continue
+
+        best_row["words"].append(word)
+        best_row["top"] = min(best_row["top"], top)
+        best_row["bottom"] = max(best_row["bottom"], bottom)
+        best_row["center"] = (best_row["top"] + best_row["bottom"]) / 2
+
+    return [
+        sorted(row["words"], key=lambda word: _float_or_none(word.get("x0")) or 0)
+        for row in sorted(rows, key=lambda row: row["top"])
+        if row["words"]
     ]
 
 
@@ -761,7 +906,9 @@ def _extract_multi_column_text_from_words(page: Any) -> str | None:
     return "\n\n".join(result_blocks)
 
 
-def _extract_form_content_from_words(page: Any) -> str | None:
+def _extract_form_content_from_words(
+    page: Any, image_entries: list[dict[str, Any]] | None = None
+) -> str | None:
     """
     Extract form-style content from a PDF page by analyzing word positions.
     This handles borderless forms/tables where words are aligned in columns.
@@ -777,26 +924,15 @@ def _extract_form_content_from_words(page: Any) -> str | None:
     if not words:
         return None
 
-    # Group words by their Y position (rows)
-    y_tolerance = 5
-    rows_by_y: dict[float, list[dict]] = {}
-    for word in words:
-        y_key = round(word["top"] / y_tolerance) * y_tolerance
-        if y_key not in rows_by_y:
-            rows_by_y[y_key] = []
-        rows_by_y[y_key].append(word)
-
-    # Sort rows by Y position
-    sorted_y_keys = sorted(rows_by_y.keys())
     page_width = page.width if hasattr(page, "width") else 612
 
     # First pass: analyze each row
     row_info: list[dict] = []
-    for y_key in sorted_y_keys:
-        row_words = sorted(rows_by_y[y_key], key=lambda w: w["x0"])
+    for row_words in _group_words_by_visual_row(words):
         if not row_words:
             continue
 
+        y_key = min(word["top"] for word in row_words)
         first_x0 = row_words[0]["x0"]
         last_x1 = row_words[-1]["x1"]
         line_width = last_x1 - first_x0
@@ -945,23 +1081,137 @@ def _extract_form_content_from_words(page: Any) -> str | None:
     # Build output - collect table data first, then format with proper column widths
     result_lines: list[str] = []
     num_cols = len(global_columns)
+    page_height = page.height if hasattr(page, "height") else 792
+
+    def assign_col(x0: float) -> int:
+        assigned_col = num_cols - 1
+        for col_idx in range(num_cols - 1):
+            col_end = global_columns[col_idx + 1]
+            if x0 < col_end - 20:
+                assigned_col = col_idx
+                break
+        return assigned_col
+
+    def append_cell_content(
+        cells: list[str], col_idx: int, content: str, separator: str = " "
+    ) -> None:
+        if cells[col_idx]:
+            if cells[col_idx].startswith("![") and separator == " ":
+                separator = "<br>"
+            cells[col_idx] += f"{separator}{content}"
+        else:
+            cells[col_idx] = content
+
+    def prepend_cell_content(
+        cells: list[str], col_idx: int, content: str, separator: str = "<br>"
+    ) -> None:
+        if cells[col_idx]:
+            cells[col_idx] = f"{content}{separator}{cells[col_idx]}"
+        else:
+            cells[col_idx] = content
+
+    def image_overlaps_row(image_entry: dict[str, Any], info: dict) -> bool:
+        image_top = image_entry.get("top")
+        image_bottom = image_entry.get("bottom")
+        if image_top is None or image_bottom is None:
+            return False
+
+        row_words = info["words"]
+        image_x0 = image_entry.get("x0")
+        image_x1 = image_entry.get("x1")
+        if image_x0 is not None and image_x1 is not None:
+            max_horizontal_gap = max(80, min(160, page_width * 0.25))
+            nearby_words = [
+                word
+                for word in row_words
+                if word["x1"] >= image_x0 - 20
+                and word["x0"] <= image_x1 + max_horizontal_gap
+            ]
+            if not nearby_words:
+                return False
+            row_words = nearby_words
+
+        row_top = min(word["top"] for word in row_words)
+        row_bottom = max(word["bottom"] for word in row_words)
+        return min(image_bottom, row_bottom) > max(image_top, row_top)
+
+    def consume_images_for_row(info: dict) -> list[dict[str, Any]]:
+        if not image_entries:
+            return []
+
+        row_images: list[dict[str, Any]] = []
+        for image_entry in image_entries:
+            if image_entry.get("used") or image_entry.get("x0") is None:
+                continue
+            if not image_overlaps_row(image_entry, info):
+                continue
+
+            image_entry["used"] = True
+            row_images.append(image_entry)
+
+        return sorted(row_images, key=lambda image_entry: image_entry["x0"])
+
+    def consume_images_above_table_header(info: dict) -> list[dict[str, Any]]:
+        if not image_entries:
+            return []
+
+        row_top = min(word["top"] for word in info["words"])
+        max_vertical_gap = max(24, min(48, page_height * 0.04))
+        candidates_by_col: dict[int, list[dict[str, Any]]] = {}
+
+        for image_entry in image_entries:
+            image_x0 = image_entry.get("x0")
+            image_top = image_entry.get("top")
+            image_bottom = image_entry.get("bottom")
+            if (
+                image_entry.get("used")
+                or image_x0 is None
+                or image_top is None
+                or image_bottom is None
+            ):
+                continue
+
+            vertical_gap = row_top - image_bottom
+            if vertical_gap < -3 or vertical_gap > max_vertical_gap:
+                continue
+
+            col_idx = assign_col(image_x0)
+            candidates_by_col.setdefault(col_idx, []).append(image_entry)
+
+        header_images: list[dict[str, Any]] = []
+        for col_idx, candidates in candidates_by_col.items():
+            for image_entry in candidates:
+                image_entry["used"] = True
+
+            chosen = max(
+                candidates,
+                key=lambda image_entry: (
+                    (image_entry.get("x1") or image_entry.get("x0") or 0)
+                    - (image_entry.get("x0") or 0)
+                )
+                * (
+                    (image_entry.get("bottom") or image_entry.get("top") or 0)
+                    - (image_entry.get("top") or 0)
+                ),
+            )
+            header_images.append(chosen)
+
+        return sorted(header_images, key=lambda image_entry: image_entry["x0"])
 
     # Helper function to extract cells from a row
     def extract_cells(info: dict) -> list[str]:
         cells: list[str] = ["" for _ in range(num_cols)]
+        for image_entry in consume_images_for_row(info):
+            append_cell_content(
+                cells,
+                assign_col(image_entry["x0"]),
+                image_entry["markdown"],
+                "<br>",
+            )
+
         for word in info["words"]:
             word_x = word["x0"]
-            # Find the correct column using boundary ranges
-            assigned_col = num_cols - 1  # Default to last column
-            for col_idx in range(num_cols - 1):
-                col_end = global_columns[col_idx + 1]
-                if word_x < col_end - 20:
-                    assigned_col = col_idx
-                    break
-            if cells[assigned_col]:
-                cells[assigned_col] += " " + word["text"]
-            else:
-                cells[assigned_col] = word["text"]
+            append_cell_content(cells, assign_col(word_x), word["text"])
         return cells
 
     # Process rows, collecting table data for proper formatting
@@ -984,43 +1234,16 @@ def _extract_form_content_from_words(page: Any) -> str | None:
                 cells = extract_cells(row_info[table_idx])
                 table_data.append(cells)
 
-            # Calculate column widths for this table
             if table_data:
-                col_widths = [
-                    max(len(row[col]) for row in table_data) for col in range(num_cols)
-                ]
-                # Ensure minimum width of 3 for separator dashes
-                col_widths = [max(w, 3) for w in col_widths]
-
-                # Format header row
-                header = table_data[0]
-                header_str = (
-                    "| "
-                    + " | ".join(
-                        cell.ljust(col_widths[i]) for i, cell in enumerate(header)
+                for image_entry in consume_images_above_table_header(row_info[start]):
+                    prepend_cell_content(
+                        table_data[0],
+                        assign_col(image_entry["x0"]),
+                        image_entry["markdown"],
                     )
-                    + " |"
+                result_lines.extend(
+                    _to_markdown_table(table_data, pad_cells=True).splitlines()
                 )
-                result_lines.append(header_str)
-
-                # Format separator row
-                separator = (
-                    "| "
-                    + " | ".join("-" * col_widths[i] for i in range(num_cols))
-                    + " |"
-                )
-                result_lines.append(separator)
-
-                # Format data rows
-                for row in table_data[1:]:
-                    row_str = (
-                        "| "
-                        + " | ".join(
-                            cell.ljust(col_widths[i]) for i, cell in enumerate(row)
-                        )
-                        + " |"
-                    )
-                    result_lines.append(row_str)
 
             idx = end  # Skip to end of table region
         else:
@@ -1033,7 +1256,11 @@ def _extract_form_content_from_words(page: Any) -> str | None:
 
             if not in_table:
                 # Non-table content
-                result_lines.append(info["text"])
+                row_images = [
+                    image_entry["markdown"]
+                    for image_entry in consume_images_for_row(info)
+                ]
+                result_lines.append(" ".join([*row_images, info["text"]]))
             idx += 1
 
     return "\n".join(result_lines)
@@ -1235,13 +1462,25 @@ class PdfConverter(DocumentConverter):
                             text = page.extract_text()
                         page_has_text_layer = bool((text or "").strip())
 
-                    page_image_chunks = (
-                        _extract_pdf_image_markdown(
+                    page_image_entries = (
+                        _extract_pdf_image_entries(
                             page, page_idx + 1, page_has_text_layer
                         )
                         if keep_data_uris
                         else []
                     )
+                    if chunk_kind == "form" and page_image_entries:
+                        text_with_images = _extract_form_content_from_words(
+                            page, page_image_entries
+                        )
+                        if text_with_images is not None:
+                            text = text_with_images
+
+                    page_image_chunks = [
+                        image_entry["markdown"]
+                        for image_entry in page_image_entries
+                        if not image_entry.get("used")
+                    ]
 
                     if page_image_chunks:
                         image_chunks.extend(page_image_chunks)

--- a/packages/markitdown/tests/test_pdf_memory.py
+++ b/packages/markitdown/tests/test_pdf_memory.py
@@ -19,6 +19,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from markitdown import MarkItDown
+from markitdown.converters._pdf_converter import _to_markdown_table
 
 TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 
@@ -170,6 +171,37 @@ def _make_two_column_table_page():
         {"text": "Bob", "x0": 340, "x1": 370, "top": 130, "bottom": 142},
     ]
     page.extract_text.return_value = "Name Alice\nDate 2026\nOwner Bob"
+    return page
+
+
+def _make_baseline_offset_table_page():
+    """Create a mock page where one visual table row has shifted baselines."""
+    page = MagicMock()
+    page.width = 840
+    page.height = 595
+    page.close = MagicMock()
+    page.extract_words.return_value = [
+        {"text": "Wide", "x0": 45, "x1": 70, "top": 100, "bottom": 108},
+        {"text": "A", "x0": 170, "x1": 180, "top": 100, "bottom": 108},
+        {"text": "B", "x0": 275, "x1": 285, "top": 100, "bottom": 108},
+        {"text": "C", "x0": 380, "x1": 390, "top": 100, "bottom": 108},
+        {"text": "D", "x0": 485, "x1": 495, "top": 100, "bottom": 108},
+        {"text": "E", "x0": 590, "x1": 600, "top": 100, "bottom": 108},
+        {"text": "F", "x0": 700, "x1": 710, "top": 100, "bottom": 108},
+        {"text": "Gateway modules", "x0": 45, "x1": 150, "top": 180, "bottom": 192},
+        {"text": "Feature", "x0": 45, "x1": 75, "top": 230, "bottom": 238},
+        {"text": "Protocol A", "x0": 170, "x1": 230, "top": 230, "bottom": 240},
+        {"text": "Protocol B", "x0": 275, "x1": 335, "top": 230, "bottom": 240},
+        {"text": "Protocol C", "x0": 380, "x1": 440, "top": 230, "bottom": 240},
+        {"text": "Order No.", "x0": 45, "x1": 90, "top": 246.1, "bottom": 254.1},
+        {"text": "R1.001", "x0": 170, "x1": 215, "top": 247.5, "bottom": 255.5},
+        {"text": "R1.002", "x0": 275, "x1": 320, "top": 247.5, "bottom": 255.5},
+        {"text": "R1.003", "x0": 380, "x1": 425, "top": 247.5, "bottom": 255.5},
+        {"text": "Approval", "x0": 45, "x1": 90, "top": 260, "bottom": 268},
+        {"text": "CE", "x0": 170, "x1": 185, "top": 261.5, "bottom": 269.5},
+        {"text": "UL", "x0": 275, "x1": 290, "top": 261.5, "bottom": 269.5},
+        {"text": "UKCA", "x0": 380, "x1": 410, "top": 261.5, "bottom": 269.5},
+    ]
     return page
 
 
@@ -543,6 +575,247 @@ class TestPdfMemoryOptimization:
 
         assert "Plain text content" in result.text_content
         assert "![PDF page 1 image 1](data:image/jpeg;base64," in result.text_content
+
+    def test_keep_data_uris_places_form_row_images_in_table_cells(self):
+        """Images positioned inside form rows should stay with those rows."""
+        page = _make_form_page()
+        page.images = [
+            _make_pdf_image(x0=50, top=24, width=36, height=26),
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        image_prefix = "![PDF page 1 image 1](data:image/jpeg;base64,"
+        alpha_row = next(
+            line for line in result.text_content.splitlines() if "Alpha" in line
+        )
+
+        assert image_prefix in alpha_row
+        assert result.text_content.count(image_prefix) == 1
+
+    def test_keep_data_uris_form_table_images_do_not_expand_table_padding(self):
+        """Image data URIs should not leave huge padded table rows after rewrite."""
+        page = _make_form_page()
+        page.images = [
+            _make_pdf_image(x0=50, top=24, width=36, height=26),
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        rewritten = re.sub(
+            r"data:image/[^)]+",
+            "https://example.invalid/image.jpg",
+            result.text_content,
+        )
+        lines = rewritten.splitlines()
+
+        assert max(len(line) for line in lines) < 160
+        assert all(
+            len(line) < 80 for line in lines if line.startswith("|") and "---" in line
+        )
+
+    def test_markdown_table_compacts_long_link_cells(self):
+        """Long links should not determine Markdown table padding widths."""
+        long_url = f"https://example.invalid/{'a' * 300}/asset.jpg"
+        markdown = _to_markdown_table(
+            [
+                ["Name", "Download"],
+                ["Alpha", f"[datasheet]({long_url})"],
+            ]
+        )
+        rewritten = markdown.replace(long_url, "https://example.invalid/asset.jpg")
+        lines = rewritten.splitlines()
+
+        assert max(len(line) for line in lines) < 120
+        assert all(
+            len(line) < 40 for line in lines if line.startswith("|") and "---" in line
+        )
+
+    def test_form_table_merges_overlapping_baselines_and_trims_empty_columns(self):
+        """Visual table rows should not split when cell baselines differ slightly."""
+        page = _make_baseline_offset_table_page()
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+            )
+
+        def normalize_row(line: str) -> str:
+            return (
+                "| "
+                + " | ".join(cell.strip() for cell in line.strip("|").split("|"))
+                + " |"
+            )
+
+        table_rows = [
+            normalize_row(line)
+            for line in result.text_content.splitlines()
+            if line.startswith("|") and ("Protocol" in line or "Order No." in line)
+        ]
+        normalized_text = "\n".join(
+            normalize_row(line) if line.startswith("|") else line
+            for line in result.text_content.splitlines()
+        )
+
+        assert "| Order No. | R1.001 | R1.002 | R1.003 |" in normalized_text
+        assert "Order No.\n|" not in normalized_text
+        assert "| Feature | Protocol A | Protocol B | Protocol C |" in normalized_text
+        assert all(not row.endswith(" |  |  |  |") for row in table_rows)
+
+    def test_keep_data_uris_places_images_above_table_header_in_header_cells(self):
+        """Images just above a table header should stay in their matching columns."""
+        page = _make_baseline_offset_table_page()
+        page.images = [
+            _make_pdf_image(x0=170, top=205, width=36, height=22),
+            _make_pdf_image(x0=275, top=205, width=36, height=22),
+            _make_pdf_image(x0=380, top=205, width=36, height=22),
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        header_row = next(
+            line for line in result.text_content.splitlines() if "Protocol A" in line
+        )
+
+        for image_number in [1, 2, 3]:
+            image_prefix = f"![PDF page 1 image {image_number}](data:image/jpeg;base64,"
+            assert image_prefix in header_row
+            assert result.text_content.count(image_prefix) == 1
+
+    def test_keep_data_uris_places_form_non_table_row_images_with_row_text(self):
+        """Images in form pages should stay near matching non-table rows too."""
+        page = _make_form_page()
+        page.extract_words.return_value = [
+            {
+                "text": "Standalone product row",
+                "x0": 50,
+                "x1": 180,
+                "top": 80,
+                "bottom": 90,
+            },
+            *page.extract_words.return_value,
+        ]
+        page.images = [
+            _make_pdf_image(x0=50, top=76, width=36, height=28),
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        image_prefix = "![PDF page 1 image 1](data:image/jpeg;base64,"
+        standalone_row = next(
+            line
+            for line in result.text_content.splitlines()
+            if "Standalone product row" in line
+        )
+
+        assert image_prefix in standalone_row
+        assert result.text_content.count(image_prefix) == 1
+
+    def test_keep_data_uris_ignores_far_right_text_when_matching_row_images(self):
+        """A distant side label should not claim a nearby product image."""
+        page = _make_form_page()
+        page.width = 900
+        page.extract_words.return_value = [
+            *page.extract_words.return_value,
+            {
+                "text": "Side label",
+                "x0": 820,
+                "x1": 860,
+                "top": 30,
+                "bottom": 70,
+            },
+        ]
+        page.images = [
+            _make_pdf_image(x0=50, top=45, width=36, height=30),
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        image_prefix = "![PDF page 1 image 1](data:image/jpeg;base64,"
+        alpha_row = next(
+            line for line in result.text_content.splitlines() if "Alpha" in line
+        )
+        beta_row = next(
+            line for line in result.text_content.splitlines() if "Beta" in line
+        )
+
+        assert image_prefix not in alpha_row
+        assert image_prefix in beta_row
+        assert result.text_content.count(image_prefix) == 1
 
     def test_keep_data_uris_reuses_page_text_for_image_filtering(self):
         """Plain pages with images should extract page text only once."""


### PR DESCRIPTION
## Summary
- Keep PDF form-table images close to matching rows and columns instead of appending them after page content.
- Compact Markdown tables when cells contain embedded images or very long content so data-URI-to-URL rewrites do not leave huge padded separators.
- Merge slightly shifted text baselines into the same visual row and trim empty trailing columns per table.
- Place images positioned just above a table header into their matching header columns while avoiding duplicate image emissions.

## Changes
- PDF converter now tracks image coordinates as structured entries and consumes them when they belong to form rows or header-adjacent table columns.
- Form-style row grouping now uses visual row centers rather than rounded top buckets, which avoids splitting rows when text baselines differ slightly.
- Markdown table formatting now supports compact output for image-heavy or long-cell tables and trims all-empty trailing columns per table.
- Regression coverage was added for row image placement, non-table row image placement, side-label matching, compact table output, shifted-baseline rows, empty-column trimming, and header-adjacent images.

## Testing
- `uv run --project packages/markitdown --extra all --with black black --check packages/markitdown/src/markitdown/converters/_pdf_converter.py packages/markitdown/tests/test_pdf_memory.py`
- `uv run --project packages/markitdown --extra all --with pytest pytest packages/markitdown/tests/test_pdf_memory.py packages/markitdown/tests/test_pdf_tables.py packages/markitdown/tests/test_pdf_masterformat.py -q`
- Real API conversion check against the provided PDF returned HTTP 200 with 0 `data:image` entries, 0 lines over 1000 chars, and the gateway-module table preserved as one compact table with header images in matching columns.

## Risk & Compatibility
- Medium risk in PDF form/table extraction behavior because row grouping and table formatting heuristics changed.
- No breaking API changes identified from the diff; image preservation still requires `keep_data_uris` or the API default/env behavior.
- Rollback is contained to the PDF converter changes in `packages/markitdown`.

## Review Notes
- Please pay special attention to the new visual-row grouping and header-adjacent image matching heuristics, especially documents with side labels or multi-row table headers.