### PR TITLE
fix(docker): require safe exiftool runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,22 @@
-FROM python:3.13-slim-bullseye
+FROM python:3.13-slim-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV EXIFTOOL_PATH=/usr/bin/exiftool
+ENV EXIFTOOL_MIN_VERSION=12.24
 ENV FFMPEG_PATH=/usr/bin/ffmpeg
 
 # Runtime dependency
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
-    exiftool
+    libimage-exiftool-perl
 
 ARG INSTALL_GIT=false
 RUN if [ "$INSTALL_GIT" = "true" ]; then \
     apt-get install -y --no-install-recommends \
     git; \
     fi
+
+RUN python -c 'import os, subprocess, sys; min_version = tuple(map(int, os.environ["EXIFTOOL_MIN_VERSION"].split("."))); version_output = subprocess.check_output(["exiftool", "-ver"], text=True).strip(); version = tuple(map(int, version_output.split("."))); sys.exit(0 if version >= min_version else "ExifTool " + version_output + " is older than required " + os.environ["EXIFTOOL_MIN_VERSION"])'
 
 # Cleanup
 RUN rm -rf /var/lib/apt/lists/*

--- a/packages/Dockerfile
+++ b/packages/Dockerfile
@@ -1,7 +1,8 @@
-FROM python:3.13-slim-bullseye
+FROM python:3.13-slim-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV EXIFTOOL_PATH=/usr/bin/exiftool
+ENV EXIFTOOL_MIN_VERSION=12.24
 ENV FFMPEG_PATH=/usr/bin/ffmpeg
 ENV MARKITDOWN_ENABLE_PLUGINS=True
 
@@ -9,8 +10,10 @@ ENV MARKITDOWN_ENABLE_PLUGINS=True
 # NOTE: Add any additional MarkItDown plugins here
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
-    exiftool \
+    libimage-exiftool-perl \
     git
+
+RUN python -c 'import os, subprocess, sys; min_version = tuple(map(int, os.environ["EXIFTOOL_MIN_VERSION"].split("."))); version_output = subprocess.check_output(["exiftool", "-ver"], text=True).strip(); version = tuple(map(int, version_output.split("."))); sys.exit(0 if version >= min_version else "ExifTool " + version_output + " is older than required " + os.environ["EXIFTOOL_MIN_VERSION"])'
 
 # Cleanup
 RUN rm -rf /var/lib/apt/lists/*

--- a/packages/markitdown-api/tests/test_docker_runtime.py
+++ b/packages/markitdown-api/tests/test_docker_runtime.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOCKERFILES_WITH_EXIFTOOL = [
+    REPO_ROOT / "Dockerfile",
+    REPO_ROOT / "packages" / "Dockerfile",
+    REPO_ROOT / "packages" / "markitdown-mcp" / "Dockerfile",
+]
+
+
+def test_exiftool_runtime_images_use_safe_debian_package_source() -> None:
+    unsafe_base = "slim-bullseye"
+
+    for dockerfile in DOCKERFILES_WITH_EXIFTOOL:
+        text = dockerfile.read_text()
+
+        assert unsafe_base not in text, (
+            f"{dockerfile.relative_to(REPO_ROOT)} installs ExifTool from Debian "
+            "bullseye, whose apt candidate is 12.16 and is rejected by "
+            "MarkItDown's CVE-2021-22204 guard."
+        )
+
+
+def test_exiftool_runtime_images_verify_minimum_version_at_build_time() -> None:
+    for dockerfile in DOCKERFILES_WITH_EXIFTOOL:
+        text = dockerfile.read_text()
+
+        assert "EXIFTOOL_MIN_VERSION=12.24" in text
+        assert '["exiftool", "-ver"]' in text

--- a/packages/markitdown-mcp/Dockerfile
+++ b/packages/markitdown-mcp/Dockerfile
@@ -1,7 +1,8 @@
-FROM python:3.13-slim-bullseye
+FROM python:3.13-slim-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV EXIFTOOL_PATH=/usr/bin/exiftool
+ENV EXIFTOOL_MIN_VERSION=12.24
 ENV FFMPEG_PATH=/usr/bin/ffmpeg
 ENV MARKITDOWN_ENABLE_PLUGINS=True
 
@@ -9,7 +10,9 @@ ENV MARKITDOWN_ENABLE_PLUGINS=True
 # NOTE: Add any additional MarkItDown plugins here
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
-    exiftool
+    libimage-exiftool-perl
+
+RUN python -c 'import os, subprocess, sys; min_version = tuple(map(int, os.environ["EXIFTOOL_MIN_VERSION"].split("."))); version_output = subprocess.check_output(["exiftool", "-ver"], text=True).strip(); version = tuple(map(int, version_output.split("."))); sys.exit(0 if version >= min_version else "ExifTool " + version_output + " is older than required " + os.environ["EXIFTOOL_MIN_VERSION"])'
 
 # Cleanup
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Update Docker runtime images from Debian bullseye to bookworm so apt installs an ExifTool version accepted by MarkItDown's CVE-2021-22204 guard.
- Install the explicit Debian package `libimage-exiftool-perl` and add a build-time `EXIFTOOL_MIN_VERSION=12.24` check.
- Add a regression test that prevents Dockerfiles from returning to the unsafe bullseye ExifTool package source or dropping the build-time version check.

## Changes
- Docker runtime images now use `python:3.13-slim-bookworm` in the root, API, and MCP Dockerfiles.
- ExifTool installation now targets `libimage-exiftool-perl` directly while preserving `/usr/bin/exiftool` through `EXIFTOOL_PATH`.
- The API test suite includes Docker runtime checks for the safe base image and ExifTool version gate.

## Testing
- `env PYTHONPATH=packages/markitdown-api/src:packages/markitdown/src uv run --with pytest --with requests --with beautifulsoup4 --with markdownify --with magika --with charset-normalizer --with defusedxml --with 'fastapi[standard]>=0.115.14' --with openai --with oss2 python -m pytest packages/markitdown-api/tests/test_convert_http.py packages/markitdown-api/tests/test_docker_runtime.py -q`
- `docker build --check -f Dockerfile .`
- `docker build --check -f packages/markitdown-mcp/Dockerfile packages/markitdown-mcp`
- `docker build -f packages/Dockerfile packages -t markitdown-api-exiftool-test:local`
- `docker run --rm --entrypoint exiftool markitdown-api-exiftool-test:local -ver`
- `docker run --rm --entrypoint markitdown markitdown-api-exiftool-test:local /app/markitdown/tests/test_files/test.jpg`

## Risk & Compatibility
- Medium operational risk: the runtime base image moves from Debian bullseye to bookworm, so system library versions change across the affected Docker images.
- No public API or configuration breaking change identified from the diff.
- Rollback is the previous image tag, but that would reintroduce the unsafe ExifTool 12.16 runtime for image conversion.

## Review Notes
- Please review the Docker base image change and the build-time ExifTool version check closely.