### PR TITLE
fix(conversion): improve PDF image and RAG output quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,6 @@ cython_debug/
 src/.DS_Store
 .DS_Store
 .cursorrules
+
+# Generated conversion artifacts may contain source-document content.
+/output/

--- a/packages/markitdown-api/src/markitdown_api/api_converter.py
+++ b/packages/markitdown-api/src/markitdown_api/api_converter.py
@@ -36,11 +36,13 @@ class ApiConverter:
             selector=self.request.html.selector if self.request.html else None,
         )
         markdown = remove_all_zw_chars(converted_result.markdown)
-        markdown = replace_data_images_with_oss_urls(markdown)
         if self.request.rag.enabled:
             markdown = optimize_markdown_for_rag(
-                markdown, heading_keywords=self.request.rag.heading_keywords
+                markdown,
+                heading_keywords=self.request.rag.heading_keywords,
+                document_title=converted_result.title,
             )
+        markdown = replace_data_images_with_oss_urls(markdown)
         result = ConvertResult(
             title=converted_result.title,
             markdown=markdown,

--- a/packages/markitdown-api/src/markitdown_api/oss_image_upload.py
+++ b/packages/markitdown-api/src/markitdown_api/oss_image_upload.py
@@ -169,12 +169,18 @@ def replace_data_images_with_oss_urls(
         )
         return markdown
 
+    uploaded_urls: dict[tuple[str, str], str] = {}
+
     def replace(match: re.Match) -> str:
         mimetype = match.group("mimetype")
         payload = "".join(match.group("payload").split())
         try:
             content = base64.b64decode(payload, validate=True)
-            url = uploader.upload_image(mimetype, content)
+            cache_key = (mimetype.lower(), hashlib.sha256(content).hexdigest())
+            url = uploaded_urls.get(cache_key)
+            if url is None:
+                url = uploader.upload_image(mimetype, content)
+                uploaded_urls[cache_key] = url
         except Exception as exc:
             logger.warning(
                 "Failed to upload embedded image to OSS; keeping data URI: %s",

--- a/packages/markitdown-api/src/markitdown_api/rag_markdown.py
+++ b/packages/markitdown-api/src/markitdown_api/rag_markdown.py
@@ -8,6 +8,17 @@ _FENCE_RE = re.compile(r"^ {0,3}(?P<marker>`{3,}|~{3,})")
 _TABLE_SEPARATOR_RE = re.compile(r"^\|?(?:\s*:?-{3,}:?\s*\|)+(?:\s*:?-{3,}:?\s*)?\|?$")
 _DATE_RE = re.compile(r"\b\d{4}[/-]\d{1,2}[/-]\d{1,2}\b")
 _PDF_IMAGE_LINE_RE = re.compile(r"^!\[(?:.* - )?PDF page \d+ image \d+\]\(")
+_WRAPPED_DATA_IMAGE_START_RE = re.compile(
+    r"^!\[(?:\\.|[^\]])*\]\(" r"data:image/[A-Za-z0-9.+-]+;base64,[A-Za-z0-9+/=]*$"
+)
+_WRAPPED_DATA_IMAGE_RE = re.compile(
+    r"^!\[(?P<alt>(?:\\.|[^\]])*)\]"
+    r"\("
+    r"data:(?P<mimetype>image/[A-Za-z0-9.+-]+);base64,"
+    r"(?P<payload>[A-Za-z0-9+/=\r\n]+)"
+    r'(?P<title>\s+"(?:\\.|[^"])*")?'
+    r"\)$"
+)
 _CJK_SPACING_RE = re.compile(r"(?<=[\u3400-\u9fff])\s+(?=[\u3400-\u9fff])")
 
 _NOISE_LINES = {"+", "-", "--", "是", "否", "×", "√", "", "•"}
@@ -21,7 +32,8 @@ def optimize_markdown_for_rag(
 ) -> str:
     """Lightly normalize converted Markdown so downstream chunking has anchors."""
 
-    lines = _merge_split_registered_terms(markdown.splitlines())
+    lines = _merge_wrapped_data_image_lines(markdown.splitlines())
+    lines = _merge_split_registered_terms(lines)
     lines = _remove_repeated_page_footers(lines)
     line_counts = Counter(line.strip() for line in _non_fenced_lines(lines))
     heading_keyword_set = {
@@ -118,15 +130,15 @@ def _normalize_cjk_spacing(line: str) -> str:
 
 
 def _remove_repeated_page_footers(lines: list[str]) -> list[str]:
-    raw_lines = list(_non_fenced_raw_lines(lines))
-    footer_signatures = Counter(
+    boundary_footer_signatures = Counter(
         signature
-        for line in raw_lines
+        for line_index, line in _non_fenced_indexed_lines(lines)
+        if _next_nonblank_line_is_pdf_image(lines, line_index + 1)
         if (signature := _page_footer_signature(line)) is not None
     )
     repeated_footer_dates = {
         date_match.group(0)
-        for signature, count in footer_signatures.items()
+        for signature, count in boundary_footer_signatures.items()
         if count >= 3
         if (date_match := _DATE_RE.search(signature)) is not None
     }
@@ -147,18 +159,19 @@ def _remove_repeated_page_footers(lines: list[str]) -> list[str]:
             continue
 
         stripped = line.strip()
-        if skip_separator and _TABLE_SEPARATOR_RE.match(stripped):
+        if skip_separator and _is_table_separator_line(stripped):
             skip_separator = False
             continue
         skip_separator = False
 
         signature = _page_footer_signature(stripped)
         standalone_date = _DATE_RE.fullmatch(stripped)
+        is_pdf_footer_boundary = _next_nonblank_line_is_pdf_image(lines, line_index + 1)
         if (
             standalone_date is not None
             and standalone_date.group(0) in repeated_footer_dates
-            and _next_nonblank_line_is_pdf_image(lines, line_index + 1)
-        ) or (signature is not None and footer_signatures[signature] >= 3):
+            and is_pdf_footer_boundary
+        ) or (signature is not None and boundary_footer_signatures[signature] >= 3):
             skip_separator = stripped.startswith("|")
             continue
 
@@ -170,14 +183,23 @@ def _remove_repeated_page_footers(lines: list[str]) -> list[str]:
 def _next_nonblank_line_is_pdf_image(lines: list[str], start: int) -> bool:
     for line in lines[start:]:
         stripped = line.strip()
-        if stripped:
-            return _PDF_IMAGE_LINE_RE.match(stripped) is not None
+        if not stripped or _is_table_separator_line(stripped):
+            continue
+        return _PDF_IMAGE_LINE_RE.match(stripped) is not None
     return False
 
 
-def _non_fenced_raw_lines(lines: list[str]):
+def _is_table_separator_line(line: str) -> bool:
+    return _TABLE_SEPARATOR_RE.match(line) is not None or (
+        line.startswith("|")
+        and "-" in line
+        and re.fullmatch(r"[\s|:-]+", line) is not None
+    )
+
+
+def _non_fenced_indexed_lines(lines: list[str]):
     fence_marker: str | None = None
-    for line in lines:
+    for line_index, line in enumerate(lines):
         marker = _fence_marker(line)
         if fence_marker:
             if _is_closing_fence(marker, fence_marker):
@@ -186,7 +208,7 @@ def _non_fenced_raw_lines(lines: list[str]):
         if marker:
             fence_marker = marker
             continue
-        yield line.strip()
+        yield line_index, line.strip()
 
 
 def _page_footer_signature(line: str) -> str | None:
@@ -209,6 +231,64 @@ def _page_footer_signature(line: str) -> str | None:
         return None
 
     return f"{flattened[: page_match.start()]}#"
+
+
+def _merge_wrapped_data_image_lines(lines: list[str]) -> list[str]:
+    merged: list[str] = []
+    fence_marker: str | None = None
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        marker = _fence_marker(line)
+        if fence_marker:
+            merged.append(line)
+            if _is_closing_fence(marker, fence_marker):
+                fence_marker = None
+            i += 1
+            continue
+        if marker:
+            merged.append(line)
+            fence_marker = marker
+            i += 1
+            continue
+
+        candidate = line.strip()
+        if not _WRAPPED_DATA_IMAGE_START_RE.match(candidate):
+            merged.append(line)
+            i += 1
+            continue
+
+        merged_image = False
+        j = i + 1
+        while j < len(lines):
+            continuation = lines[j].strip()
+            if not continuation or _fence_marker(lines[j]):
+                break
+
+            candidate = f"{candidate}\n{continuation}"
+            image_match = _WRAPPED_DATA_IMAGE_RE.fullmatch(candidate)
+            if image_match is not None:
+                payload = "".join(image_match.group("payload").split())
+                title = image_match.group("title") or ""
+                merged.append(
+                    f"![{image_match.group('alt')}]"
+                    f"(data:{image_match.group('mimetype')};base64,{payload}{title})"
+                )
+                i = j + 1
+                merged_image = True
+                break
+
+            if re.fullmatch(r"[A-Za-z0-9+/=]+", continuation) is None:
+                break
+            j += 1
+
+        if merged_image:
+            continue
+
+        merged.append(line)
+        i += 1
+
+    return merged
 
 
 def _merge_split_registered_terms(lines: list[str]) -> list[str]:

--- a/packages/markitdown-api/src/markitdown_api/rag_markdown.py
+++ b/packages/markitdown-api/src/markitdown_api/rag_markdown.py
@@ -7,6 +7,7 @@ _MARKDOWN_IMAGE_RE = re.compile(
 _FENCE_RE = re.compile(r"^ {0,3}(?P<marker>`{3,}|~{3,})")
 _TABLE_SEPARATOR_RE = re.compile(r"^\|?(?:\s*:?-{3,}:?\s*\|)+(?:\s*:?-{3,}:?\s*)?\|?$")
 _DATE_RE = re.compile(r"\b\d{4}[/-]\d{1,2}[/-]\d{1,2}\b")
+_PDF_IMAGE_LINE_RE = re.compile(r"^!\[(?:.* - )?PDF page \d+ image \d+\]\(")
 _CJK_SPACING_RE = re.compile(r"(?<=[\u3400-\u9fff])\s+(?=[\u3400-\u9fff])")
 
 _NOISE_LINES = {"+", "-", "--", "是", "否", "×", "√", "", "•"}
@@ -109,7 +110,6 @@ def _normalize_document_title(title: str | None) -> str | None:
         return None
 
     normalized = title.strip().lstrip("#").strip()
-    normalized = re.sub(r"\.[A-Za-z0-9]{1,8}$", "", normalized)
     return normalized or None
 
 
@@ -134,7 +134,7 @@ def _remove_repeated_page_footers(lines: list[str]) -> list[str]:
     output: list[str] = []
     fence_marker: str | None = None
     skip_separator = False
-    for line in lines:
+    for line_index, line in enumerate(lines):
         marker = _fence_marker(line)
         if fence_marker:
             output.append(line)
@@ -157,6 +157,7 @@ def _remove_repeated_page_footers(lines: list[str]) -> list[str]:
         if (
             standalone_date is not None
             and standalone_date.group(0) in repeated_footer_dates
+            and _next_nonblank_line_is_pdf_image(lines, line_index + 1)
         ) or (signature is not None and footer_signatures[signature] >= 3):
             skip_separator = stripped.startswith("|")
             continue
@@ -164,6 +165,14 @@ def _remove_repeated_page_footers(lines: list[str]) -> list[str]:
         output.append(line)
 
     return output
+
+
+def _next_nonblank_line_is_pdf_image(lines: list[str], start: int) -> bool:
+    for line in lines[start:]:
+        stripped = line.strip()
+        if stripped:
+            return _PDF_IMAGE_LINE_RE.match(stripped) is not None
+    return False
 
 
 def _non_fenced_raw_lines(lines: list[str]):

--- a/packages/markitdown-api/src/markitdown_api/rag_markdown.py
+++ b/packages/markitdown-api/src/markitdown_api/rag_markdown.py
@@ -5,16 +5,23 @@ _MARKDOWN_IMAGE_RE = re.compile(
     r"^!\[(?P<alt>(?:\\.|[^\]])*)\]" r"\(" r"(?P<target>[^)]*)" r"\)$"
 )
 _FENCE_RE = re.compile(r"^ {0,3}(?P<marker>`{3,}|~{3,})")
+_TABLE_SEPARATOR_RE = re.compile(r"^\|?(?:\s*:?-{3,}:?\s*\|)+(?:\s*:?-{3,}:?\s*)?\|?$")
+_DATE_RE = re.compile(r"\b\d{4}[/-]\d{1,2}[/-]\d{1,2}\b")
+_CJK_SPACING_RE = re.compile(r"(?<=[\u3400-\u9fff])\s+(?=[\u3400-\u9fff])")
 
-_NOISE_LINES = {"+", "-", "--", "是", "否", "×", "√"}
+_NOISE_LINES = {"+", "-", "--", "是", "否", "×", "√", "", "•"}
 
 
 def optimize_markdown_for_rag(
-    markdown: str, *, heading_keywords: list[str] | None = None
+    markdown: str,
+    *,
+    heading_keywords: list[str] | None = None,
+    document_title: str | None = None,
 ) -> str:
     """Lightly normalize converted Markdown so downstream chunking has anchors."""
 
     lines = _merge_split_registered_terms(markdown.splitlines())
+    lines = _remove_repeated_page_footers(lines)
     line_counts = Counter(line.strip() for line in _non_fenced_lines(lines))
     heading_keyword_set = {
         keyword.strip() for keyword in (heading_keywords or []) if keyword.strip()
@@ -24,6 +31,13 @@ def optimize_markdown_for_rag(
     current_context: str | None = None
     title_seen = False
     fence_marker: str | None = None
+
+    normalized_document_title = _normalize_document_title(document_title)
+    source_title_candidate_checked = False
+    if normalized_document_title:
+        output.append(f"# {normalized_document_title}")
+        current_context = normalized_document_title
+        title_seen = True
 
     for raw_line in lines:
         marker = _fence_marker(raw_line)
@@ -37,7 +51,7 @@ def optimize_markdown_for_rag(
             fence_marker = marker
             continue
 
-        line = raw_line.strip()
+        line = _normalize_cjk_spacing(raw_line.strip())
 
         if not line:
             if output and output[-1] != "":
@@ -49,6 +63,11 @@ def optimize_markdown_for_rag(
 
         if line in _NOISE_LINES:
             continue
+
+        if normalized_document_title and not source_title_candidate_checked:
+            source_title_candidate_checked = True
+            if _plain_heading_text(line) == normalized_document_title:
+                continue
 
         image_match = _MARKDOWN_IMAGE_RE.match(line)
         if image_match:
@@ -70,8 +89,9 @@ def optimize_markdown_for_rag(
 
         if _is_likely_section_heading(line, line_counts, heading_keyword_set):
             heading = line if line.startswith("#") else f"## {line}"
+            heading_text = _plain_heading_text(heading)
             output.append(heading)
-            current_context = _plain_heading_text(heading)
+            current_context = heading_text
             continue
 
         if _is_context_line(line):
@@ -82,6 +102,104 @@ def optimize_markdown_for_rag(
         output.pop()
 
     return "\n".join(output)
+
+
+def _normalize_document_title(title: str | None) -> str | None:
+    if title is None:
+        return None
+
+    normalized = title.strip().lstrip("#").strip()
+    normalized = re.sub(r"\.[A-Za-z0-9]{1,8}$", "", normalized)
+    return normalized or None
+
+
+def _normalize_cjk_spacing(line: str) -> str:
+    return _CJK_SPACING_RE.sub("", line)
+
+
+def _remove_repeated_page_footers(lines: list[str]) -> list[str]:
+    raw_lines = list(_non_fenced_raw_lines(lines))
+    footer_signatures = Counter(
+        signature
+        for line in raw_lines
+        if (signature := _page_footer_signature(line)) is not None
+    )
+    repeated_footer_dates = {
+        date_match.group(0)
+        for signature, count in footer_signatures.items()
+        if count >= 3
+        if (date_match := _DATE_RE.search(signature)) is not None
+    }
+
+    output: list[str] = []
+    fence_marker: str | None = None
+    skip_separator = False
+    for line in lines:
+        marker = _fence_marker(line)
+        if fence_marker:
+            output.append(line)
+            if _is_closing_fence(marker, fence_marker):
+                fence_marker = None
+            continue
+        if marker:
+            output.append(line)
+            fence_marker = marker
+            continue
+
+        stripped = line.strip()
+        if skip_separator and _TABLE_SEPARATOR_RE.match(stripped):
+            skip_separator = False
+            continue
+        skip_separator = False
+
+        signature = _page_footer_signature(stripped)
+        standalone_date = _DATE_RE.fullmatch(stripped)
+        if (
+            standalone_date is not None
+            and standalone_date.group(0) in repeated_footer_dates
+        ) or (signature is not None and footer_signatures[signature] >= 3):
+            skip_separator = stripped.startswith("|")
+            continue
+
+        output.append(line)
+
+    return output
+
+
+def _non_fenced_raw_lines(lines: list[str]):
+    fence_marker: str | None = None
+    for line in lines:
+        marker = _fence_marker(line)
+        if fence_marker:
+            if _is_closing_fence(marker, fence_marker):
+                fence_marker = None
+            continue
+        if marker:
+            fence_marker = marker
+            continue
+        yield line.strip()
+
+
+def _page_footer_signature(line: str) -> str | None:
+    if not line or (date_match := _DATE_RE.search(line)) is None:
+        return None
+
+    flattened = re.sub(r"\s*\|\s*", " ", line).strip()
+    flattened = re.sub(r"\s+", " ", flattened)
+    date_match = _DATE_RE.search(flattened)
+    page_match = re.search(r"\b\d{1,3}\s*$", flattened)
+    if (
+        date_match is None
+        or page_match is None
+        or page_match.start() <= date_match.end()
+    ):
+        return None
+
+    middle = flattened[date_match.end() : page_match.start()]
+    if re.search(r"[^\W\d_]", middle, re.UNICODE) is None:
+        return None
+
+    return f"{flattened[: page_match.start()]}#"
 
 
 def _merge_split_registered_terms(lines: list[str]) -> list[str]:

--- a/packages/markitdown-api/tests/test_oss_image_upload.py
+++ b/packages/markitdown-api/tests/test_oss_image_upload.py
@@ -47,6 +47,35 @@ def test_replace_data_images_uploads_and_rewrites_markdown_image():
     assert uploader.calls == [("image/png", image_bytes)]
 
 
+def test_replace_data_images_uploads_duplicate_content_once():
+    image_bytes = b"shared-image-bytes"
+    encoded = base64.b64encode(image_bytes).decode("ascii")
+    markdown = (
+        f"![first](data:image/png;base64,{encoded})\n"
+        f"![second](data:image/png;base64,{encoded})"
+    )
+
+    class FakeUploader:
+        def __init__(self):
+            self.calls = []
+
+        def upload_image(self, mimetype, content):
+            self.calls.append((mimetype, content))
+            return "https://cdn.example.com/images/shared.png"
+
+    uploader = FakeUploader()
+
+    rewritten = replace_data_images_with_oss_urls(
+        markdown, uploader_factory=lambda: uploader
+    )
+
+    assert rewritten == (
+        "![first](https://cdn.example.com/images/shared.png)\n"
+        "![second](https://cdn.example.com/images/shared.png)"
+    )
+    assert uploader.calls == [("image/png", image_bytes)]
+
+
 def test_replace_data_images_keeps_data_uri_when_oss_is_unavailable():
     image_bytes = b"fake-png-bytes"
     encoded = base64.b64encode(image_bytes).decode("ascii")

--- a/packages/markitdown-api/tests/test_rag_markdown.py
+++ b/packages/markitdown-api/tests/test_rag_markdown.py
@@ -157,6 +157,107 @@ this suffix is too long"""
     )
 
 
+def test_optimize_markdown_for_rag_uses_document_title_as_stable_h1():
+    markdown = """从一个组件开始
+这个示例端子
+开 始
+"""
+
+    assert (
+        optimize_markdown_for_rag(markdown, document_title="示例工业公司介绍（for 示例客户）.pdf")
+        == """# 示例工业公司介绍（for 示例客户）
+从一个组件开始
+这个示例端子
+开始"""
+    )
+
+
+def test_optimize_markdown_for_rag_does_not_repeat_matching_source_title():
+    markdown = """Example Document
+Body text
+"""
+
+    assert (
+        optimize_markdown_for_rag(markdown, document_title="Example Document.pdf")
+        == """# Example Document
+Body text"""
+    )
+
+
+def test_optimize_markdown_for_rag_keeps_repeated_section_headings():
+    markdown = """Report
+## Summary
+First section
+## Summary
+Second section
+"""
+
+    assert (
+        optimize_markdown_for_rag(markdown)
+        == """# Report
+## Summary
+First section
+## Summary
+Second section"""
+    )
+
+
+def test_optimize_markdown_for_rag_keeps_repeated_content_dates():
+    markdown = """Events
+2024/6/1
+First event
+2024/6/1
+Second event
+2024/6/1
+Third event
+"""
+
+    optimized = optimize_markdown_for_rag(markdown)
+
+    assert optimized.count("2024/6/1") == 3
+
+
+def test_optimize_markdown_for_rag_keeps_distinct_dated_rows():
+    markdown = """Schedule
+2024/6/1 Alpha release 1
+2024/6/2 Alpha release 2
+2024/6/3 Alpha release 3
+"""
+
+    optimized = optimize_markdown_for_rag(markdown)
+
+    assert "2024/6/1 Alpha release 1" in optimized
+    assert "2024/6/2 Alpha release 2" in optimized
+    assert "2024/6/3 Alpha release 3" in optimized
+
+
+def test_optimize_markdown_for_rag_removes_pdf_footers_and_preserves_cross_page_images():
+    markdown = """产品介绍
+2024/6/1 ACME ELECTRIC - DOC 2
+![PDF page 2 image 1](data:image/png;base64,c2hhcmVk)
+
+功能安全
+| 2024/6/1 | ACME ELECTRIC - | DOC | 3 |
+| ---------- | ----------------- | -- | - |
+![PDF page 3 image 1](data:image/png;base64,c2hhcmVk)
+
+安全服务
+2024/6/1 ACME ELECTRIC - DOC 4
+![PDF page 4 image 2](https://cdn.example.com/unique.png)
+
+产品清单
+2024/6/1
+"""
+
+    optimized = optimize_markdown_for_rag(markdown, document_title="示例工业公司介绍.pdf")
+
+    assert optimized.startswith("# 示例工业公司介绍\n")
+    assert "2024/6/1" not in optimized
+    assert optimized.count("data:image/png;base64,c2hhcmVk") == 2
+    assert optimized.count("https://cdn.example.com/unique.png") == 1
+    assert "![产品介绍 - PDF page 2 image 1]" in optimized
+
+
 def test_api_converter_applies_rag_optimizer_by_default(monkeypatch):
     markdown = "产品目录\n2\n"
 
@@ -196,3 +297,35 @@ def test_api_converter_uses_configured_rag_heading_keywords(monkeypatch):
         .result.markdown
         == "# 产品目录\n\n## 目录"
     )
+
+
+def test_api_converter_cleans_before_upload_without_removing_image_references(
+    monkeypatch,
+):
+    markdown = """Document
+![PDF page 1 image 1](data:image/png;base64,c2hhcmVk)
+![PDF page 2 image 1](data:image/png;base64,c2hhcmVk)
+"""
+    observed = []
+
+    class StubApiConverter(ApiConverter):
+        def _internal_convert(self, **kwargs):
+            return DocumentConverterResult(markdown=markdown, title="Document")
+
+    def fake_upload(markdown_value):
+        observed.append(markdown_value)
+        return markdown_value.replace(
+            "data:image/png;base64,c2hhcmVk", "https://cdn.example.com/shared.png"
+        )
+
+    monkeypatch.setattr(
+        "markitdown_api.api_converter.replace_data_images_with_oss_urls", fake_upload
+    )
+
+    result = StubApiConverter(ConvertRequest()).convert().result.markdown
+
+    assert len(observed) == 1
+    assert observed[0].splitlines().count("# Document") == 1
+    assert observed[0].splitlines().count("Document") == 0
+    assert observed[0].count("data:image/png;base64,c2hhcmVk") == 2
+    assert result.count("https://cdn.example.com/shared.png") == 2

--- a/packages/markitdown-api/tests/test_rag_markdown.py
+++ b/packages/markitdown-api/tests/test_rag_markdown.py
@@ -244,6 +244,20 @@ def test_optimize_markdown_for_rag_keeps_distinct_dated_rows():
     assert "2024/6/3 Alpha release 3" in optimized
 
 
+def test_optimize_markdown_for_rag_keeps_repeated_dated_rows_with_numeric_suffixes():
+    markdown = """Report
+2024/6/1 Release phase 1
+2024/6/1 Release phase 2
+2024/6/1 Release phase 3
+"""
+
+    optimized = optimize_markdown_for_rag(markdown)
+
+    assert "2024/6/1 Release phase 1" in optimized
+    assert "2024/6/1 Release phase 2" in optimized
+    assert "2024/6/1 Release phase 3" in optimized
+
+
 def test_optimize_markdown_for_rag_removes_pdf_footers_and_preserves_cross_page_images():
     markdown = """产品介绍
 2024/6/1 ACME ELECTRIC - DOC 2
@@ -257,6 +271,10 @@ def test_optimize_markdown_for_rag_removes_pdf_footers_and_preserves_cross_page_
 安全服务
 2024/6/1 ACME ELECTRIC - DOC 4
 ![PDF page 4 image 2](https://cdn.example.com/unique.png)
+
+附录
+2024/6/1 ACME ELECTRIC - DOC 5
+Closing text
 """
 
     optimized = optimize_markdown_for_rag(markdown, document_title="示例工业公司介绍")
@@ -271,12 +289,15 @@ def test_optimize_markdown_for_rag_removes_pdf_footers_and_preserves_cross_page_
 def test_optimize_markdown_for_rag_only_removes_standalone_date_at_pdf_image_boundary():
     markdown = """Report
 2024/6/1 ACME DOC 1
+![PDF page 1 image 1](https://cdn.example.com/page-1.png)
 Details
 2024/6/1 ACME DOC 2
+![PDF page 2 image 1](https://cdn.example.com/page-2.png)
 Business date
 2024/6/1
 Description continues
 2024/6/1 ACME DOC 3
+![PDF page 3 image 1](https://cdn.example.com/page-3.png)
 Product page
 2024/6/1
 ![PDF page 4 image 1](https://cdn.example.com/product.png)
@@ -366,6 +387,7 @@ def test_api_converter_uploads_wrapped_data_uri_after_rag_cleanup(monkeypatch):
     markdown = """Document
 ![chart](data:image/png;base64,QUJD
 REVG)
+![PDF page 2 image 1](https://cdn.example.com/next.png)
 """
     upload_calls = []
 
@@ -387,5 +409,9 @@ REVG)
 
     result = StubApiConverter(ConvertRequest()).convert().result.markdown
 
-    assert result == "# Document\n![chart](https://cdn.example.com/chart.png)"
+    assert result == (
+        "# Document\n"
+        "![chart](https://cdn.example.com/chart.png)\n"
+        "![Document - PDF page 2 image 1](https://cdn.example.com/next.png)"
+    )
     assert upload_calls == [("image/png", b"ABCDEF")]

--- a/packages/markitdown-api/tests/test_rag_markdown.py
+++ b/packages/markitdown-api/tests/test_rag_markdown.py
@@ -2,6 +2,7 @@ from markitdown import DocumentConverterResult
 
 from markitdown_api.api_converter import ApiConverter
 from markitdown_api.api_types import ConvertRequest, RagOptions
+from markitdown_api.oss_image_upload import replace_data_images_with_oss_urls
 from markitdown_api.rag_markdown import optimize_markdown_for_rag
 
 
@@ -164,7 +165,7 @@ def test_optimize_markdown_for_rag_uses_document_title_as_stable_h1():
 """
 
     assert (
-        optimize_markdown_for_rag(markdown, document_title="示例工业公司介绍（for 示例客户）.pdf")
+        optimize_markdown_for_rag(markdown, document_title="示例工业公司介绍（for 示例客户）")
         == """# 示例工业公司介绍（for 示例客户）
 从一个组件开始
 这个示例端子
@@ -178,8 +179,20 @@ Body text
 """
 
     assert (
-        optimize_markdown_for_rag(markdown, document_title="Example Document.pdf")
+        optimize_markdown_for_rag(markdown, document_title="Example Document")
         == """# Example Document
+Body text"""
+    )
+
+
+def test_optimize_markdown_for_rag_preserves_dots_in_document_title():
+    markdown = """manual.v2
+Body text
+"""
+
+    assert (
+        optimize_markdown_for_rag(markdown, document_title="manual.v2")
+        == """# manual.v2
 Body text"""
     )
 
@@ -244,18 +257,36 @@ def test_optimize_markdown_for_rag_removes_pdf_footers_and_preserves_cross_page_
 安全服务
 2024/6/1 ACME ELECTRIC - DOC 4
 ![PDF page 4 image 2](https://cdn.example.com/unique.png)
-
-产品清单
-2024/6/1
 """
 
-    optimized = optimize_markdown_for_rag(markdown, document_title="示例工业公司介绍.pdf")
+    optimized = optimize_markdown_for_rag(markdown, document_title="示例工业公司介绍")
 
     assert optimized.startswith("# 示例工业公司介绍\n")
     assert "2024/6/1" not in optimized
     assert optimized.count("data:image/png;base64,c2hhcmVk") == 2
     assert optimized.count("https://cdn.example.com/unique.png") == 1
     assert "![产品介绍 - PDF page 2 image 1]" in optimized
+
+
+def test_optimize_markdown_for_rag_only_removes_standalone_date_at_pdf_image_boundary():
+    markdown = """Report
+2024/6/1 ACME DOC 1
+Details
+2024/6/1 ACME DOC 2
+Business date
+2024/6/1
+Description continues
+2024/6/1 ACME DOC 3
+Product page
+2024/6/1
+![PDF page 4 image 1](https://cdn.example.com/product.png)
+"""
+
+    optimized = optimize_markdown_for_rag(markdown)
+
+    assert "Business date\n2024/6/1\nDescription continues" in optimized
+    assert "Product page\n2024/6/1\n![" not in optimized
+    assert "![Product page - PDF page 4 image 1]" in optimized
 
 
 def test_api_converter_applies_rag_optimizer_by_default(monkeypatch):
@@ -329,3 +360,32 @@ def test_api_converter_cleans_before_upload_without_removing_image_references(
     assert observed[0].splitlines().count("Document") == 0
     assert observed[0].count("data:image/png;base64,c2hhcmVk") == 2
     assert result.count("https://cdn.example.com/shared.png") == 2
+
+
+def test_api_converter_uploads_wrapped_data_uri_after_rag_cleanup(monkeypatch):
+    markdown = """Document
+![chart](data:image/png;base64,QUJD
+REVG)
+"""
+    upload_calls = []
+
+    class StubApiConverter(ApiConverter):
+        def _internal_convert(self, **kwargs):
+            return DocumentConverterResult(markdown=markdown, title="Document")
+
+    class FakeUploader:
+        def upload_image(self, mimetype, content):
+            upload_calls.append((mimetype, content))
+            return "https://cdn.example.com/chart.png"
+
+    monkeypatch.setattr(
+        "markitdown_api.api_converter.replace_data_images_with_oss_urls",
+        lambda markdown_value: replace_data_images_with_oss_urls(
+            markdown_value, uploader_factory=FakeUploader
+        ),
+    )
+
+    result = StubApiConverter(ConvertRequest()).convert().result.markdown
+
+    assert result == "# Document\n![chart](https://cdn.example.com/chart.png)"
+    assert upload_calls == [("image/png", b"ABCDEF")]

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -1,5 +1,6 @@
 import sys
 import base64
+import hashlib
 import io
 import os
 import re
@@ -59,6 +60,16 @@ def _merge_partial_numbering_lines(text: str) -> str:
     return "\n".join(result_lines)
 
 
+def _pdf_document_title(stream_info: StreamInfo) -> str | None:
+    filename = stream_info.filename
+    if not filename:
+        return None
+
+    basename = os.path.basename(filename).strip()
+    title, _ = os.path.splitext(basename)
+    return title.strip() or None
+
+
 # Load dependencies
 _dependency_exc_info = None
 try:
@@ -70,10 +81,11 @@ except ImportError:
     _dependency_exc_info = sys.exc_info()
 
 try:
-    from PIL import Image, ImageChops, ImageStat
+    from PIL import Image, ImageChops, ImageMath, ImageStat
 except ImportError:
     Image = None
     ImageChops = None
+    ImageMath = None
     ImageStat = None
 
 
@@ -83,6 +95,8 @@ ACCEPTED_MIME_TYPE_PREFIXES = [
 ]
 
 ACCEPTED_FILE_EXTENSIONS = [".pdf"]
+
+_PDF_LOW_OPACITY_ALPHA_MAX = 127
 
 
 def _pdf_name(value: Any) -> str:
@@ -237,7 +251,7 @@ def _flate_pdf_image_to_pil(data: bytes, attrs: dict[Any, Any]) -> Any | None:
     return image
 
 
-def _dct_cmyk_pdf_image_to_jpeg(data: bytes, attrs: dict[Any, Any]) -> bytes | None:
+def _dct_cmyk_pdf_image_to_pil(data: bytes, attrs: dict[Any, Any]) -> Any | None:
     if Image is None or ImageChops is None:
         return None
 
@@ -255,7 +269,182 @@ def _dct_cmyk_pdf_image_to_jpeg(data: bytes, attrs: dict[Any, Any]) -> bytes | N
         return None
 
     white = Image.new("CMYK", image.size, (255, 255, 255, 255))
-    image = ImageChops.subtract(white, image).convert("RGB")
+    return ImageChops.subtract(white, image).convert("RGB")
+
+
+def _pdf_image_stream_to_pil(data: bytes, attrs: dict[Any, Any]) -> Any | None:
+    if Image is None:
+        return None
+
+    filters = attrs.get("Filter")
+    if "FlateDecode" in _pdf_filter_names(filters):
+        return _flate_pdf_image_to_pil(data, attrs)
+    if "DCTDecode" in _pdf_filter_names(filters):
+        cmyk_image = _dct_cmyk_pdf_image_to_pil(data, attrs)
+        if cmyk_image is not None:
+            return cmyk_image
+
+    try:
+        image = Image.open(io.BytesIO(data))
+        image.load()
+        return image
+    except Exception:
+        return None
+
+
+def _pdf_soft_mask_to_alpha(
+    attrs: dict[Any, Any], target_size: tuple[int, int]
+) -> tuple[Any, dict[Any, Any]] | None:
+    if Image is None:
+        return None
+
+    soft_mask = _resolve_pdf_value(attrs.get("SMask"))
+    if soft_mask is None or not hasattr(soft_mask, "get_data"):
+        return None
+
+    soft_mask_attrs = getattr(soft_mask, "attrs", {})
+    try:
+        soft_mask_data = soft_mask.get_data()
+    except Exception:
+        return None
+
+    mask_image = _pdf_image_stream_to_pil(soft_mask_data, soft_mask_attrs)
+    if mask_image is None:
+        return None
+
+    alpha = mask_image.convert("L")
+    decode = _resolve_pdf_value(soft_mask_attrs.get("Decode"))
+    if isinstance(decode, (list, tuple)) and len(decode) >= 2:
+        try:
+            minimum = float(decode[0])
+            maximum = float(decode[1])
+            alpha = alpha.point(
+                lambda value: max(
+                    0,
+                    min(
+                        255,
+                        round(255 * (minimum + (value / 255) * (maximum - minimum))),
+                    ),
+                )
+            )
+        except (TypeError, ValueError):
+            pass
+
+    if alpha.size != target_size:
+        resampling = getattr(Image, "Resampling", Image)
+        alpha = alpha.resize(target_size, resampling.LANCZOS)
+
+    return alpha, soft_mask_attrs
+
+
+def _pdf_matte_rgb(
+    image_attrs: dict[Any, Any], soft_mask_attrs: dict[Any, Any]
+) -> tuple[int, int, int] | None:
+    matte = _resolve_pdf_value(soft_mask_attrs.get("Matte"))
+    if not isinstance(matte, (list, tuple)):
+        return None
+
+    try:
+        components = [
+            max(0, min(255, round(float(component) * 255))) for component in matte
+        ]
+    except (TypeError, ValueError):
+        return None
+
+    colorspace = _resolve_pdf_value(image_attrs.get("ColorSpace"))
+    colorspace_name = _pdf_name(colorspace)
+    if colorspace_name == "DeviceRGB" and len(components) >= 3:
+        return components[0], components[1], components[2]
+    if colorspace_name == "DeviceGray" and components:
+        return (components[0],) * 3
+    if colorspace_name == "DeviceCMYK" and len(components) >= 4:
+        return _cmyk_to_rgb_components(*components[:4])
+    return None
+
+
+def _remove_pdf_matte(
+    image: Any, alpha: Any, matte: tuple[int, int, int] | None
+) -> Any:
+    rgb = image.convert("RGB")
+    if matte is None or ImageMath is None:
+        return rgb
+
+    evaluator = getattr(ImageMath, "unsafe_eval", None) or getattr(
+        ImageMath, "eval", None
+    )
+    if evaluator is None:
+        return rgb
+
+    corrected_channels = []
+    for channel, matte_component in zip(rgb.split(), matte):
+        try:
+            corrected = evaluator(
+                "convert(m + (c - m) * 255 / max(a, 1), 'L')",
+                c=channel,
+                a=alpha,
+                m=matte_component,
+            )
+        except Exception:
+            return rgb
+        corrected_channels.append(corrected)
+
+    return Image.merge("RGB", tuple(corrected_channels))
+
+
+def _pdf_image_with_soft_mask(data: bytes, attrs: dict[Any, Any]) -> Any | None:
+    image = _pdf_image_stream_to_pil(data, attrs)
+    if image is None:
+        return None
+
+    soft_mask = _pdf_soft_mask_to_alpha(attrs, image.size)
+    if soft_mask is None:
+        return None
+
+    alpha, soft_mask_attrs = soft_mask
+    matte = _pdf_matte_rgb(attrs, soft_mask_attrs)
+    rgb = _remove_pdf_matte(image, alpha, matte)
+    rgba = rgb.convert("RGBA")
+    rgba.putalpha(alpha)
+    return rgba
+
+
+def _is_translucent_grayscale_effect(image: Any) -> bool:
+    if (
+        not _pdf_image_filter_enabled()
+        or Image is None
+        or ImageChops is None
+        or "A" not in image.getbands()
+    ):
+        return False
+
+    if image.getchannel("A").getextrema()[1] >= 250:
+        return False
+
+    sample = image.resize((64, 64))
+    red, green, blue = sample.convert("RGB").split()
+    red_green_difference = ImageChops.difference(red, green).getextrema()[1]
+    red_blue_difference = ImageChops.difference(red, blue).getextrema()[1]
+    return red_green_difference <= 4 and red_blue_difference <= 4
+
+
+def _encode_pdf_image_with_alpha(image: Any, filters: Any) -> tuple[str, bytes]:
+    if "DCTDecode" in _pdf_filter_names(filters):
+        webp_stream = io.BytesIO()
+        try:
+            image.save(webp_stream, format="WEBP", quality=95, method=4)
+            return "image/webp", webp_stream.getvalue()
+        except (KeyError, OSError, ValueError):
+            pass
+
+    png_stream = io.BytesIO()
+    image.save(png_stream, format="PNG", optimize=True)
+    return "image/png", png_stream.getvalue()
+
+
+def _dct_cmyk_pdf_image_to_jpeg(data: bytes, attrs: dict[Any, Any]) -> bytes | None:
+    image = _dct_cmyk_pdf_image_to_pil(data, attrs)
+    if image is None:
+        return None
 
     jpeg_stream = io.BytesIO()
     image.save(jpeg_stream, format="JPEG", quality=95, optimize=True)
@@ -373,6 +562,9 @@ def _is_obvious_framework_pdf_image(
     if area_ratio <= 0.0015 and max_dimension <= 80:
         return True
 
+    if _is_low_opacity_solid_black_pdf_image(image):
+        return True
+
     if _is_low_contrast_flate_mask(image):
         return True
 
@@ -384,6 +576,43 @@ def _is_obvious_framework_pdf_image(
         return True
 
     return False
+
+
+def _is_low_opacity_solid_black_pdf_image(image: Any) -> bool:
+    if Image is None or not isinstance(image, dict):
+        return False
+
+    stream = image.get("stream")
+    if stream is None:
+        return False
+
+    attrs = getattr(stream, "attrs", {})
+    if attrs.get("SMask") is None:
+        return False
+
+    try:
+        data = stream.get_data()
+    except Exception:
+        return False
+
+    image_value = _pdf_image_stream_to_pil(data, attrs)
+    if image_value is None:
+        return False
+
+    try:
+        extrema = image_value.convert("RGB").getextrema()
+    except Exception:
+        return False
+
+    if not all(maximum <= 1 for _, maximum in extrema):
+        return False
+
+    soft_mask = _pdf_soft_mask_to_alpha(attrs, image_value.size)
+    if soft_mask is None:
+        return False
+
+    alpha, _ = soft_mask
+    return alpha.getextrema()[1] <= _PDF_LOW_OPACITY_ALPHA_MAX
 
 
 def _is_low_contrast_flate_mask(image: Any) -> bool:
@@ -436,6 +665,18 @@ def _pdf_image_to_data_uri(image: Any) -> str | None:
 
     attrs = getattr(stream, "attrs", {})
     filters = attrs.get("Filter")
+    if attrs.get("SMask") is not None:
+        image_with_soft_mask = _pdf_image_with_soft_mask(data, attrs)
+        if image_with_soft_mask is not None:
+            if _is_translucent_grayscale_effect(image_with_soft_mask):
+                return None
+
+            mimetype, image_data = _encode_pdf_image_with_alpha(
+                image_with_soft_mask, filters
+            )
+            payload = base64.b64encode(image_data).decode("ascii")
+            return f"data:{mimetype};base64,{payload}"
+
     if "DCTDecode" in _pdf_filter_names(filters):
         jpeg_data = _dct_cmyk_pdf_image_to_jpeg(data, attrs)
         if jpeg_data is not None:
@@ -459,10 +700,75 @@ def _pdf_image_to_data_uri(image: Any) -> str | None:
     return f"data:{mimetype};base64,{payload}"
 
 
+def _is_pdf_header_image(page: Any, image: Any) -> bool:
+    if not isinstance(image, dict):
+        return False
+
+    page_width = _float_or_none(getattr(page, "width", None))
+    page_height = _float_or_none(getattr(page, "height", None))
+    image_width, image_height = _pdf_image_dimensions(image)
+    top = _float_or_none(image.get("top"))
+    bottom = _float_or_none(image.get("bottom"))
+    if (
+        page_width is None
+        or page_height is None
+        or image_width is None
+        or image_height is None
+        or top is None
+        or bottom is None
+        or image_height <= 0
+    ):
+        return False
+
+    return (
+        top <= page_height * 0.15
+        and bottom <= page_height * 0.20
+        and image_height <= page_height * 0.12
+        and image_width <= page_width * 0.40
+        and image_width / image_height >= 1.8
+    )
+
+
+def _pdf_header_image_signature(data_uri: str) -> Any | None:
+    if Image is None:
+        return None
+
+    metadata, separator, payload = data_uri.partition(",")
+    if not separator or ";base64" not in metadata:
+        return None
+
+    try:
+        image_data = base64.b64decode(payload, validate=True)
+        image = Image.open(io.BytesIO(image_data)).convert("RGBA")
+        alpha_bbox = image.getchannel("A").getbbox()
+        if alpha_bbox is None:
+            return None
+        image = image.crop(alpha_bbox)
+        background = Image.new("RGBA", image.size, "white")
+        image = Image.alpha_composite(background, image).convert("RGB")
+        resampling = getattr(Image, "Resampling", Image)
+        return image.resize((256, 48), resampling.LANCZOS)
+    except Exception:
+        return None
+
+
+def _pdf_header_images_match(first: Any, second: Any) -> bool:
+    if ImageChops is None or ImageStat is None:
+        return False
+
+    difference = ImageChops.difference(first, second)
+    statistics = ImageStat.Stat(difference)
+    return max(statistics.mean) <= 18 and max(statistics.rms) <= 32
+
+
 def _extract_pdf_image_markdown(
-    page: Any, page_number: int, page_has_text_layer: bool | None = None
+    page: Any,
+    page_number: int,
+    page_has_text_layer: bool | None = None,
+    seen_header_images: list[tuple[bytes, Any | None]] | None = None,
 ) -> list[str]:
     markdown_images: list[str] = []
+    seen_page_image_digests: set[bytes] = set()
     if page_has_text_layer is None:
         try:
             page_has_text_layer = bool((page.extract_text() or "").strip())
@@ -476,6 +782,26 @@ def _extract_pdf_image_markdown(
         data_uri = _pdf_image_to_data_uri(image)
         if data_uri is None:
             continue
+
+        image_digest = hashlib.sha256(data_uri.encode("ascii")).digest()
+        if image_digest in seen_page_image_digests:
+            continue
+        seen_page_image_digests.add(image_digest)
+
+        if seen_header_images is not None and _is_pdf_header_image(page, image):
+            signature = _pdf_header_image_signature(data_uri)
+            if any(
+                image_digest == seen_digest
+                or (
+                    signature is not None
+                    and seen_signature is not None
+                    and _pdf_header_images_match(signature, seen_signature)
+                )
+                for seen_digest, seen_signature in seen_header_images
+            ):
+                continue
+            seen_header_images.append((image_digest, signature))
+
         alt_text = f"PDF page {page_number} image {image_number}"
         markdown_images.append(f"![{alt_text}]({data_uri})")
     return markdown_images
@@ -1215,6 +1541,7 @@ class PdfConverter(DocumentConverter):
             page_chunks: list[dict[str, Any]] = []
             form_page_count = 0
             multi_column_page_count = 0
+            seen_header_images: list[tuple[bytes, Any | None]] = []
 
             with pdfplumber.open(pdf_bytes) as pdf:
                 for page_idx, page in enumerate(pdf.pages):
@@ -1237,7 +1564,10 @@ class PdfConverter(DocumentConverter):
 
                     page_image_chunks = (
                         _extract_pdf_image_markdown(
-                            page, page_idx + 1, page_has_text_layer
+                            page,
+                            page_idx + 1,
+                            page_has_text_layer,
+                            seen_header_images,
                         )
                         if keep_data_uris
                         else []
@@ -1291,4 +1621,6 @@ class PdfConverter(DocumentConverter):
         # Post-process to merge MasterFormat-style partial numbering with following text
         markdown = _merge_partial_numbering_lines(markdown)
 
-        return DocumentConverterResult(markdown=markdown)
+        return DocumentConverterResult(
+            markdown=markdown, title=_pdf_document_title(stream_info)
+        )

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -4,6 +4,7 @@ import hashlib
 import io
 import os
 import re
+from dataclasses import dataclass, field
 from typing import BinaryIO, Any
 
 from .._base_converter import DocumentConverter, DocumentConverterResult
@@ -97,6 +98,17 @@ ACCEPTED_MIME_TYPE_PREFIXES = [
 ACCEPTED_FILE_EXTENSIONS = [".pdf"]
 
 _PDF_LOW_OPACITY_ALPHA_MAX = 127
+_PDF_DECORATIVE_EFFECT_OVERLAP_RATIO = 0.90
+_PDF_HEADER_MIN_REPEAT_PAGES = 3
+
+
+@dataclass
+class _PdfHeaderImageGroup:
+    digest: bytes
+    signature: Any | None
+    page_numbers: set[int] = field(default_factory=set)
+    occurrences: list[tuple[list[str], str]] = field(default_factory=list)
+    confirmed: bool = False
 
 
 def _pdf_name(value: Any) -> str:
@@ -427,6 +439,69 @@ def _is_translucent_grayscale_effect(image: Any) -> bool:
     return red_green_difference <= 4 and red_blue_difference <= 4
 
 
+def _pdf_image_box(image: Any) -> tuple[float, float, float, float] | None:
+    if not isinstance(image, dict):
+        return None
+
+    x0 = _float_or_none(image.get("x0"))
+    x1 = _float_or_none(image.get("x1"))
+    top = _float_or_none(image.get("top"))
+    bottom = _float_or_none(image.get("bottom"))
+    if x0 is None or x1 is None or top is None or bottom is None:
+        return None
+    if x1 <= x0 or bottom <= top:
+        return None
+    return x0, top, x1, bottom
+
+
+def _pdf_images_overlap_ratio(first: Any, second: Any) -> float:
+    first_box = _pdf_image_box(first)
+    second_box = _pdf_image_box(second)
+    if first_box is None or second_box is None:
+        return 0.0
+
+    first_x0, first_top, first_x1, first_bottom = first_box
+    second_x0, second_top, second_x1, second_bottom = second_box
+    overlap_width = max(0.0, min(first_x1, second_x1) - max(first_x0, second_x0))
+    overlap_height = max(
+        0.0, min(first_bottom, second_bottom) - max(first_top, second_top)
+    )
+    overlap_area = overlap_width * overlap_height
+    first_area = (first_x1 - first_x0) * (first_bottom - first_top)
+    second_area = (second_x1 - second_x0) * (second_bottom - second_top)
+    return overlap_area / min(first_area, second_area)
+
+
+def _is_paired_translucent_grayscale_effect(page: Any, image: Any) -> bool:
+    if not isinstance(image, dict):
+        return False
+
+    stream = image.get("stream")
+    if stream is None:
+        return False
+
+    attrs = getattr(stream, "attrs", {})
+    if attrs.get("SMask") is None:
+        return False
+
+    try:
+        image_with_soft_mask = _pdf_image_with_soft_mask(stream.get_data(), attrs)
+    except Exception:
+        return False
+
+    if image_with_soft_mask is None or not _is_translucent_grayscale_effect(
+        image_with_soft_mask
+    ):
+        return False
+
+    return any(
+        other is not image
+        and _pdf_images_overlap_ratio(image, other)
+        >= _PDF_DECORATIVE_EFFECT_OVERLAP_RATIO
+        for other in (getattr(page, "images", []) or [])
+    )
+
+
 def _encode_pdf_image_with_alpha(image: Any, filters: Any) -> tuple[str, bytes]:
     if "DCTDecode" in _pdf_filter_names(filters):
         webp_stream = io.BytesIO()
@@ -565,6 +640,9 @@ def _is_obvious_framework_pdf_image(
     if _is_low_opacity_solid_black_pdf_image(image):
         return True
 
+    if _is_paired_translucent_grayscale_effect(page, image):
+        return True
+
     if _is_low_contrast_flate_mask(image):
         return True
 
@@ -668,9 +746,6 @@ def _pdf_image_to_data_uri(image: Any) -> str | None:
     if attrs.get("SMask") is not None:
         image_with_soft_mask = _pdf_image_with_soft_mask(data, attrs)
         if image_with_soft_mask is not None:
-            if _is_translucent_grayscale_effect(image_with_soft_mask):
-                return None
-
             mimetype, image_data = _encode_pdf_image_with_alpha(
                 image_with_soft_mask, filters
             )
@@ -765,7 +840,7 @@ def _extract_pdf_image_markdown(
     page: Any,
     page_number: int,
     page_has_text_layer: bool | None = None,
-    seen_header_images: list[tuple[bytes, Any | None]] | None = None,
+    header_image_groups: list[_PdfHeaderImageGroup] | None = None,
 ) -> list[str]:
     markdown_images: list[str] = []
     seen_page_image_digests: set[bytes] = set()
@@ -788,22 +863,44 @@ def _extract_pdf_image_markdown(
             continue
         seen_page_image_digests.add(image_digest)
 
-        if seen_header_images is not None and _is_pdf_header_image(page, image):
-            signature = _pdf_header_image_signature(data_uri)
-            if any(
-                image_digest == seen_digest
-                or (
-                    signature is not None
-                    and seen_signature is not None
-                    and _pdf_header_images_match(signature, seen_signature)
-                )
-                for seen_digest, seen_signature in seen_header_images
-            ):
-                continue
-            seen_header_images.append((image_digest, signature))
-
         alt_text = f"PDF page {page_number} image {image_number}"
-        markdown_images.append(f"![{alt_text}]({data_uri})")
+        markdown_image = f"![{alt_text}]({data_uri})"
+
+        if header_image_groups is not None and _is_pdf_header_image(page, image):
+            signature = _pdf_header_image_signature(data_uri)
+            matching_group = next(
+                (
+                    group
+                    for group in header_image_groups
+                    if image_digest == group.digest
+                    or (
+                        signature is not None
+                        and group.signature is not None
+                        and _pdf_header_images_match(signature, group.signature)
+                    )
+                ),
+                None,
+            )
+            if matching_group is None:
+                matching_group = _PdfHeaderImageGroup(
+                    digest=image_digest,
+                    signature=signature,
+                )
+                header_image_groups.append(matching_group)
+
+            if matching_group.confirmed:
+                continue
+
+            matching_group.page_numbers.add(page_number)
+            matching_group.occurrences.append((markdown_images, markdown_image))
+            if len(matching_group.page_numbers) >= _PDF_HEADER_MIN_REPEAT_PAGES:
+                matching_group.confirmed = True
+                for emitted_images, emitted_markdown in matching_group.occurrences[1:]:
+                    if emitted_markdown in emitted_images:
+                        emitted_images.remove(emitted_markdown)
+                continue
+
+        markdown_images.append(markdown_image)
     return markdown_images
 
 
@@ -1541,7 +1638,7 @@ class PdfConverter(DocumentConverter):
             page_chunks: list[dict[str, Any]] = []
             form_page_count = 0
             multi_column_page_count = 0
-            seen_header_images: list[tuple[bytes, Any | None]] = []
+            header_image_groups: list[_PdfHeaderImageGroup] = []
 
             with pdfplumber.open(pdf_bytes) as pdf:
                 for page_idx, page in enumerate(pdf.pages):
@@ -1567,14 +1664,11 @@ class PdfConverter(DocumentConverter):
                             page,
                             page_idx + 1,
                             page_has_text_layer,
-                            seen_header_images,
+                            header_image_groups,
                         )
                         if keep_data_uris
                         else []
                     )
-
-                    if page_image_chunks:
-                        image_chunks.extend(page_image_chunks)
 
                     page_chunks.append(
                         {
@@ -1585,6 +1679,10 @@ class PdfConverter(DocumentConverter):
                     )
 
                     page.close()  # Free cached page data immediately
+
+            image_chunks = [
+                image for page_chunk in page_chunks for image in page_chunk["images"]
+            ]
 
             if form_page_count == 0:
                 pdf_bytes.seek(0)

--- a/packages/markitdown/src/markitdown/converters/_pdf_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_pdf_converter.py
@@ -67,7 +67,7 @@ def _pdf_document_title(stream_info: StreamInfo) -> str | None:
         return None
 
     basename = os.path.basename(filename).strip()
-    title, _ = os.path.splitext(basename)
+    title = basename[:-4] if basename.lower().endswith(".pdf") else basename
     return title.strip() or None
 
 

--- a/packages/markitdown/tests/test_pdf_memory.py
+++ b/packages/markitdown/tests/test_pdf_memory.py
@@ -824,8 +824,8 @@ class TestPdfMemoryOptimization:
         assert list(converted.getchannel("A").tobytes()) == [0, 255, 128, 255]
 
     def test_pdf_image_filter_skips_translucent_grayscale_effect_layer(self):
-        """Standalone grayscale soft effects are rendering layers, not content."""
-        _require_pillow()
+        """A grayscale soft effect paired with content is a rendering layer."""
+        Image = _require_pillow()
         width = 100
         height = 100
         base = bytes(
@@ -842,6 +842,8 @@ class TestPdfMemoryOptimization:
             BitsPerComponent=8,
             ColorSpace="DeviceGray",
         )
+        jpeg_stream = io.BytesIO()
+        Image.new("RGB", (width, height), (255, 0, 0)).save(jpeg_stream, format="JPEG")
         page = _make_plain_page()
         page.images = [
             {
@@ -858,6 +860,73 @@ class TestPdfMemoryOptimization:
                 "x1": 180,
                 "top": 120,
                 "bottom": 220,
+                "width": width,
+                "height": height,
+            },
+            _make_pdf_image(
+                x0=80,
+                top=120,
+                width=width,
+                height=height,
+                data=jpeg_stream.getvalue(),
+            ),
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            result = MarkItDown().convert_stream(
+                io.BytesIO(b"fake pdf content"),
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert "![PDF page 1 image 1]" not in result.text_content
+        assert "![PDF page 1 image 2](data:image/jpeg;base64," in result.text_content
+        assert result.text_content.count("data:image/") == 1
+
+    def test_pdf_image_filter_keeps_meaningful_translucent_grayscale_image(self):
+        """A standalone translucent grayscale logo is content, not an effect."""
+        Image = _require_pillow()
+        width = 100
+        height = 40
+        base = bytearray([128] * (width * height * 3))
+        alpha = bytearray(width * height)
+        for y in range(8, 32):
+            for x in range(10, 90):
+                pixel = y * width + x
+                base[pixel * 3 : pixel * 3 + 3] = bytes([60, 60, 60])
+                alpha[pixel] = 160
+
+        soft_mask = _FakePdfImageStream(
+            bytes(alpha),
+            "FlateDecode",
+            Width=width,
+            Height=height,
+            BitsPerComponent=8,
+            ColorSpace="DeviceGray",
+        )
+        page = _make_plain_page()
+        page.images = [
+            {
+                "stream": _FakePdfImageStream(
+                    bytes(base),
+                    "FlateDecode",
+                    Width=width,
+                    Height=height,
+                    BitsPerComponent=8,
+                    ColorSpace="DeviceRGB",
+                    SMask=soft_mask,
+                ),
+                "x0": 80,
+                "x1": 180,
+                "top": 120,
+                "bottom": 160,
                 "width": width,
                 "height": height,
             }
@@ -877,7 +946,13 @@ class TestPdfMemoryOptimization:
                 keep_data_uris=True,
             )
 
-        assert "data:image/" not in result.text_content
+        match = re.search(
+            r"data:image/png;base64,([A-Za-z0-9+/=]+)", result.text_content
+        )
+        assert match is not None
+        converted = Image.open(io.BytesIO(base64.b64decode(match.group(1))))
+        assert converted.mode == "RGBA"
+        assert converted.getchannel("A").getextrema() == (0, 160)
 
     def test_pdf_image_filter_skips_obvious_framework_images(self):
         """PDF framework images should be skipped while content images remain."""
@@ -1226,8 +1301,8 @@ class TestPdfMemoryOptimization:
         assert "![PDF page 1 image 1](data:image/png;base64," in result.text_content
 
     def test_pdf_images_deduplicate_repeated_headers_across_pages(self):
-        """The same header image should only be emitted on its first page."""
-        pages = [_make_plain_page(), _make_plain_page()]
+        """A header repeated on at least three pages is a running header."""
+        pages = [_make_plain_page(), _make_plain_page(), _make_plain_page()]
         for page in pages:
             page.images = [
                 _make_pdf_image(
@@ -1255,10 +1330,11 @@ class TestPdfMemoryOptimization:
 
         assert "![PDF page 1 image 1]" in result.text_content
         assert "![PDF page 2 image 1]" not in result.text_content
+        assert "![PDF page 3 image 1]" not in result.text_content
         assert result.text_content.count("data:image/") == 1
 
-    def test_pdf_images_deduplicate_visually_equivalent_header_variants(self):
-        """Resized or re-encoded variants of the same header logo are duplicates."""
+    def test_pdf_images_keep_two_visually_equivalent_top_images(self):
+        """Two top-of-page matches are insufficient to confirm a running header."""
         Image = _require_pillow()
         encoded_logos = []
         for size, quality in [((120, 40), 90), ((240, 80), 95)]:
@@ -1299,8 +1375,8 @@ class TestPdfMemoryOptimization:
             )
 
         assert "![PDF page 1 image 1]" in result.text_content
-        assert "![PDF page 2 image 1]" not in result.text_content
-        assert result.text_content.count("data:image/") == 1
+        assert "![PDF page 2 image 1]" in result.text_content
+        assert result.text_content.count("data:image/") == 2
 
     def test_pdf_images_deduplicate_identical_content_within_page(self):
         """Identical image content on one page should only be emitted once."""

--- a/packages/markitdown/tests/test_pdf_memory.py
+++ b/packages/markitdown/tests/test_pdf_memory.py
@@ -295,6 +295,27 @@ class TestPdfMemoryOptimization:
 
         assert result.title == "示例工业公司介绍（for 示例客户）"
 
+    def test_pdf_preserves_dotted_filename_without_pdf_suffix_as_document_title(self):
+        page = _make_plain_page()
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            result = MarkItDown().convert_stream(
+                io.BytesIO(b"fake pdf content"),
+                stream_info=StreamInfo(
+                    mimetype="application/pdf",
+                    filename="manual.v2",
+                ),
+            )
+
+        assert result.title == "manual.v2"
+
     def test_plain_text_pdf_falls_back_to_pdfminer(self):
         """Verify all-plain-text PDFs fall back to pdfminer.
 

--- a/packages/markitdown/tests/test_pdf_memory.py
+++ b/packages/markitdown/tests/test_pdf_memory.py
@@ -18,7 +18,7 @@ import tracemalloc
 import pytest
 from unittest.mock import patch, MagicMock
 
-from markitdown import MarkItDown
+from markitdown import MarkItDown, StreamInfo
 
 TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 
@@ -189,9 +189,10 @@ def _make_pdf_image(
     width: float,
     height: float,
     data: bytes = b"\xff\xd8fake jpeg",
+    **stream_attrs,
 ):
     return {
-        "stream": _FakePdfImageStream(data, "DCTDecode"),
+        "stream": _FakePdfImageStream(data, "DCTDecode", **stream_attrs),
         "x0": x0,
         "x1": x0 + width,
         "top": top,
@@ -271,6 +272,28 @@ class TestPdfMemoryOptimization:
                 f"page.close() was NOT called on page {i} — "
                 "this would cause memory to accumulate"
             )
+
+    def test_pdf_uses_filename_as_document_title(self):
+        page = _make_plain_page()
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            result = MarkItDown().convert_stream(
+                io.BytesIO(b"fake pdf content"),
+                stream_info=StreamInfo(
+                    extension=".pdf",
+                    mimetype="application/pdf",
+                    filename="示例工业公司介绍（for 示例客户）.pdf",
+                ),
+            )
+
+        assert result.title == "示例工业公司介绍（for 示例客户）"
 
     def test_plain_text_pdf_falls_back_to_pdfminer(self):
         """Verify all-plain-text PDFs fall back to pdfminer.
@@ -641,7 +664,9 @@ class TestPdfMemoryOptimization:
         Image = _require_pillow()
 
         jpeg_stream = io.BytesIO()
-        Image.new("CMYK", (1, 1), (255, 255, 255, 255)).save(jpeg_stream, format="JPEG")
+        Image.new("CMYK", (100, 100), (255, 255, 255, 255)).save(
+            jpeg_stream, format="JPEG"
+        )
         page = _make_plain_page()
         page.images = [
             {
@@ -649,7 +674,14 @@ class TestPdfMemoryOptimization:
                     jpeg_stream.getvalue(),
                     "DCTDecode",
                     ColorSpace="DeviceCMYK",
-                )
+                    SMask=object(),
+                ),
+                "x0": 80,
+                "x1": 180,
+                "top": 120,
+                "bottom": 220,
+                "width": 100,
+                "height": 100,
             }
         ]
 
@@ -680,6 +712,172 @@ class TestPdfMemoryOptimization:
             "RGB"
         )
         assert converted.getpixel((0, 0)) == (255, 255, 255)
+
+    def test_keep_data_uris_applies_pdf_soft_mask_and_matte(self):
+        """PDF soft masks should become PNG alpha without dark matte fringes."""
+        Image = _require_pillow()
+        soft_mask = _FakePdfImageStream(
+            bytes([0, 128]),
+            "FlateDecode",
+            Width=2,
+            Height=1,
+            BitsPerComponent=8,
+            ColorSpace="DeviceGray",
+            Matte=[0, 0, 0],
+        )
+        page = _make_plain_page()
+        page.images = [
+            {
+                "stream": _FakePdfImageStream(
+                    bytes([0, 0, 0, 128, 0, 0]),
+                    "FlateDecode",
+                    Width=2,
+                    Height=1,
+                    BitsPerComponent=8,
+                    ColorSpace="DeviceRGB",
+                    SMask=soft_mask,
+                ),
+                "x0": 80,
+                "x1": 180,
+                "top": 120,
+                "bottom": 220,
+                "width": 100,
+                "height": 100,
+            }
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            result = MarkItDown().convert_stream(
+                io.BytesIO(b"fake pdf content"),
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        match = re.search(
+            r"data:image/png;base64,([A-Za-z0-9+/=]+)", result.text_content
+        )
+        assert match is not None
+
+        converted = Image.open(io.BytesIO(base64.b64decode(match.group(1))))
+        assert converted.mode == "RGBA"
+        assert converted.getpixel((0, 0))[3] == 0
+        red, green, blue, alpha = converted.getpixel((1, 0))
+        assert red >= 250
+        assert green == 0
+        assert blue == 0
+        assert alpha == 128
+
+    def test_keep_data_uris_applies_soft_mask_to_jpeg_with_alpha(self):
+        """JPEG image XObjects with a soft mask must retain an alpha channel."""
+        Image = _require_pillow()
+        jpeg_stream = io.BytesIO()
+        Image.new("RGB", (2, 2), (255, 0, 0)).save(jpeg_stream, format="JPEG")
+        soft_mask = _FakePdfImageStream(
+            bytes([0, 255, 128, 255]),
+            "FlateDecode",
+            Width=2,
+            Height=2,
+            BitsPerComponent=8,
+            ColorSpace="DeviceGray",
+        )
+        page = _make_plain_page()
+        page.images = [
+            _make_pdf_image(
+                x0=80,
+                top=120,
+                width=100,
+                height=100,
+                data=jpeg_stream.getvalue(),
+                ColorSpace="DeviceRGB",
+                SMask=soft_mask,
+            )
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            result = MarkItDown().convert_stream(
+                io.BytesIO(b"fake pdf content"),
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        match = re.search(
+            r"data:image/(?:png|webp);base64,([A-Za-z0-9+/=]+)",
+            result.text_content,
+        )
+        assert match is not None
+        converted = Image.open(io.BytesIO(base64.b64decode(match.group(1))))
+        assert converted.mode == "RGBA"
+        assert list(converted.getchannel("A").tobytes()) == [0, 255, 128, 255]
+
+    def test_pdf_image_filter_skips_translucent_grayscale_effect_layer(self):
+        """Standalone grayscale soft effects are rendering layers, not content."""
+        _require_pillow()
+        width = 100
+        height = 100
+        base = bytes(
+            40 + ((x + y) % 40)
+            for y in range(height)
+            for x in range(width)
+            for _ in range(3)
+        )
+        soft_mask = _FakePdfImageStream(
+            bytes(80 + ((x + y) % 80) for y in range(height) for x in range(width)),
+            "FlateDecode",
+            Width=width,
+            Height=height,
+            BitsPerComponent=8,
+            ColorSpace="DeviceGray",
+        )
+        page = _make_plain_page()
+        page.images = [
+            {
+                "stream": _FakePdfImageStream(
+                    base,
+                    "FlateDecode",
+                    Width=width,
+                    Height=height,
+                    BitsPerComponent=8,
+                    ColorSpace="DeviceRGB",
+                    SMask=soft_mask,
+                ),
+                "x0": 80,
+                "x1": 180,
+                "top": 120,
+                "bottom": 220,
+                "width": width,
+                "height": height,
+            }
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            result = MarkItDown().convert_stream(
+                io.BytesIO(b"fake pdf content"),
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert "data:image/" not in result.text_content
 
     def test_pdf_image_filter_skips_obvious_framework_images(self):
         """PDF framework images should be skipped while content images remain."""
@@ -753,6 +951,243 @@ class TestPdfMemoryOptimization:
 
         assert "data:image/" not in result.text_content
 
+    def test_pdf_image_filter_skips_solid_black_images(self):
+        """Low-opacity black soft-mask layers should not become black rectangles."""
+        Image = _require_pillow()
+        width = 100
+        height = 100
+        soft_mask = _FakePdfImageStream(
+            bytes([80]) * width * height,
+            "FlateDecode",
+            Width=width,
+            Height=height,
+            BitsPerComponent=8,
+            ColorSpace="DeviceGray",
+        )
+
+        jpeg_stream = io.BytesIO()
+        Image.new("RGB", (width, height), (0, 0, 0)).save(jpeg_stream, format="JPEG")
+
+        page = _make_plain_page()
+        page.images = [
+            {
+                "stream": _FakePdfImageStream(
+                    bytes(width * height * 3),
+                    "FlateDecode",
+                    Width=width,
+                    Height=height,
+                    BitsPerComponent=8,
+                    ColorSpace="DeviceRGB",
+                    SMask=soft_mask,
+                ),
+                "x0": 80,
+                "x1": 80 + width,
+                "top": 120,
+                "bottom": 120 + height,
+                "width": width,
+                "height": height,
+            },
+            _make_pdf_image(
+                x0=220,
+                top=120,
+                width=width,
+                height=height,
+                data=jpeg_stream.getvalue(),
+                SMask=soft_mask,
+            ),
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert "data:image/" not in result.text_content
+
+    def test_pdf_image_filter_keeps_solid_black_images_without_smask(self):
+        """Standalone black content must not be mistaken for a transparency layer."""
+        Image = _require_pillow()
+        width = 100
+        height = 100
+
+        jpeg_stream = io.BytesIO()
+        Image.new("RGB", (width, height), (0, 0, 0)).save(jpeg_stream, format="JPEG")
+
+        page = _make_plain_page()
+        page.images = [
+            {
+                "stream": _FakePdfImageStream(
+                    bytes(width * height * 3),
+                    "FlateDecode",
+                    Width=width,
+                    Height=height,
+                    BitsPerComponent=8,
+                    ColorSpace="DeviceRGB",
+                ),
+                "x0": 80,
+                "x1": 80 + width,
+                "top": 120,
+                "bottom": 120 + height,
+                "width": width,
+                "height": height,
+            },
+            _make_pdf_image(
+                x0=220,
+                top=120,
+                width=width,
+                height=height,
+                data=jpeg_stream.getvalue(),
+            ),
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert "![PDF page 1 image 1](data:image/png;base64," in result.text_content
+        assert "![PDF page 1 image 2](data:image/jpeg;base64," in result.text_content
+
+    def test_pdf_image_filter_skips_solid_black_cmyk_smask(self):
+        """CMYK filtering must use the same inverted-color normalization as output."""
+        Image = _require_pillow()
+        width = 100
+        height = 100
+
+        jpeg_stream = io.BytesIO()
+        Image.new("CMYK", (width, height), (0, 0, 0, 0)).save(
+            jpeg_stream, format="JPEG"
+        )
+        soft_mask = _FakePdfImageStream(
+            bytes([80]) * width * height,
+            "FlateDecode",
+            Width=width,
+            Height=height,
+            BitsPerComponent=8,
+            ColorSpace="DeviceGray",
+        )
+
+        page = _make_plain_page()
+        page.images = [
+            _make_pdf_image(
+                x0=80,
+                top=120,
+                width=width,
+                height=height,
+                data=jpeg_stream.getvalue(),
+                ColorSpace="DeviceCMYK",
+                SMask=soft_mask,
+            )
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert "data:image/" not in result.text_content
+
+    def test_pdf_image_filter_keeps_solid_black_icon_with_opaque_soft_mask(self):
+        """A meaningful opaque mask must preserve legitimate black artwork."""
+        Image = _require_pillow()
+        width = 100
+        height = 100
+        jpeg_stream = io.BytesIO()
+        Image.new("RGB", (width, height), (0, 0, 0)).save(
+            jpeg_stream, format="JPEG", quality=95
+        )
+        alpha = bytearray(width * height)
+        for y in range(25, 75):
+            for x in range(25, 75):
+                alpha[y * width + x] = 255
+        soft_mask = _FakePdfImageStream(
+            bytes(alpha),
+            "FlateDecode",
+            Width=width,
+            Height=height,
+            BitsPerComponent=8,
+            ColorSpace="DeviceGray",
+        )
+
+        page = _make_plain_page()
+        page.images = [
+            _make_pdf_image(
+                x0=80,
+                top=120,
+                width=width,
+                height=height,
+                data=jpeg_stream.getvalue(),
+                ColorSpace="DeviceRGB",
+                SMask=soft_mask,
+            )
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            md = MarkItDown()
+            buf = io.BytesIO(b"fake pdf content")
+            from markitdown import StreamInfo
+
+            result = md.convert_stream(
+                buf,
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        match = re.search(
+            r"data:image/(?:png|webp);base64,([A-Za-z0-9+/=]+)",
+            result.text_content,
+        )
+        assert match is not None
+        converted = Image.open(io.BytesIO(base64.b64decode(match.group(1))))
+        assert converted.mode == "RGBA"
+        assert converted.getchannel("A").getextrema() == (0, 255)
+
     def test_pdf_image_filter_keeps_high_contrast_flate_images(self):
         """High-contrast Flate/Indexed images such as QR codes should remain."""
         _require_pillow()
@@ -790,13 +1225,172 @@ class TestPdfMemoryOptimization:
 
         assert "![PDF page 1 image 1](data:image/png;base64," in result.text_content
 
+    def test_pdf_images_deduplicate_repeated_headers_across_pages(self):
+        """The same header image should only be emitted on its first page."""
+        pages = [_make_plain_page(), _make_plain_page()]
+        for page in pages:
+            page.images = [
+                _make_pdf_image(
+                    x0=440,
+                    top=20,
+                    width=120,
+                    height=40,
+                    data=b"\xff\xd8shared header",
+                )
+            ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open(pages)
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            result = MarkItDown().convert_stream(
+                io.BytesIO(b"fake pdf content"),
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert "![PDF page 1 image 1]" in result.text_content
+        assert "![PDF page 2 image 1]" not in result.text_content
+        assert result.text_content.count("data:image/") == 1
+
+    def test_pdf_images_deduplicate_visually_equivalent_header_variants(self):
+        """Resized or re-encoded variants of the same header logo are duplicates."""
+        Image = _require_pillow()
+        encoded_logos = []
+        for size, quality in [((120, 40), 90), ((240, 80), 95)]:
+            logo = Image.new("RGB", size, "white")
+            logo.paste((80, 180, 40), (0, 0, size[0] // 4, size[1]))
+            logo.paste(
+                (10, 10, 10),
+                (size[0] // 3, size[1] // 4, size[0], size[1] * 3 // 4),
+            )
+            jpeg_stream = io.BytesIO()
+            logo.save(jpeg_stream, format="JPEG", quality=quality)
+            encoded_logos.append(jpeg_stream.getvalue())
+
+        pages = [_make_plain_page(), _make_plain_page()]
+        for page, encoded_logo in zip(pages, encoded_logos):
+            page.images = [
+                _make_pdf_image(
+                    x0=440,
+                    top=20,
+                    width=120,
+                    height=40,
+                    data=encoded_logo,
+                )
+            ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open(pages)
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            result = MarkItDown().convert_stream(
+                io.BytesIO(b"fake pdf content"),
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert "![PDF page 1 image 1]" in result.text_content
+        assert "![PDF page 2 image 1]" not in result.text_content
+        assert result.text_content.count("data:image/") == 1
+
+    def test_pdf_images_deduplicate_identical_content_within_page(self):
+        """Identical image content on one page should only be emitted once."""
+        page = _make_plain_page()
+        page.images = [
+            _make_pdf_image(
+                x0=80,
+                top=180,
+                width=180,
+                height=100,
+                data=b"\xff\xd8same page product",
+            ),
+            _make_pdf_image(
+                x0=300,
+                top=180,
+                width=180,
+                height=100,
+                data=b"\xff\xd8same page product",
+            ),
+        ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open([page])
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            result = MarkItDown().convert_stream(
+                io.BytesIO(b"fake pdf content"),
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert "![PDF page 1 image 1]" in result.text_content
+        assert "![PDF page 1 image 2]" not in result.text_content
+        assert result.text_content.count("data:image/") == 1
+
+    def test_pdf_images_keep_identical_content_on_different_non_header_pages(self):
+        """Repeated product images on different pages preserve page semantics."""
+        pages = [_make_plain_page(), _make_plain_page()]
+        for page in pages:
+            page.images = [
+                _make_pdf_image(
+                    x0=80,
+                    top=180,
+                    width=180,
+                    height=100,
+                    data=b"\xff\xd8shared product",
+                )
+            ]
+
+        with patch(
+            "markitdown.converters._pdf_converter.pdfplumber"
+        ) as mock_pdfplumber, patch(
+            "markitdown.converters._pdf_converter.pdfminer"
+        ) as mock_pdfminer:
+            mock_pdfplumber.open.side_effect = _mock_pdfplumber_open(pages)
+            mock_pdfminer.high_level.extract_text.return_value = "Plain text content"
+
+            result = MarkItDown().convert_stream(
+                io.BytesIO(b"fake pdf content"),
+                stream_info=StreamInfo(extension=".pdf", mimetype="application/pdf"),
+                keep_data_uris=True,
+            )
+
+        assert "![PDF page 1 image 1]" in result.text_content
+        assert "![PDF page 2 image 1]" in result.text_content
+        assert result.text_content.count("data:image/") == 2
+
     def test_pdf_image_filter_can_be_disabled_with_environment(self, monkeypatch):
         """Set PDF_IMAGE_FILTER_ENABLED=false to keep all extractable images."""
         monkeypatch.setenv("PDF_IMAGE_FILTER_ENABLED", "false")
         page = _make_plain_page()
         page.images = [
-            _make_pdf_image(x0=10, top=10, width=1.5, height=700),
-            _make_pdf_image(x0=80, top=120, width=240, height=140),
+            _make_pdf_image(
+                x0=10,
+                top=10,
+                width=1.5,
+                height=700,
+                data=b"\xff\xd8framework image",
+            ),
+            _make_pdf_image(
+                x0=80,
+                top=120,
+                width=240,
+                height=140,
+                data=b"\xff\xd8content image",
+            ),
         ]
 
         with patch(


### PR DESCRIPTION
## Goal

Improve PDF image extraction and RAG-oriented Markdown quality without removing images that carry page-level meaning.

The previous pipeline emitted PDF soft-mask layers as black rectangles, repeated header logos across pages, and could upload identical embedded image content repeatedly. RAG cleanup could also duplicate the document title, remove legitimate repeated headings or dates, and discard repeated product images that should remain associated with each page.

## Changes

- Apply PDF soft masks and matte correction while preserving alpha channels.
- Filter low-opacity solid-black rendering layers while retaining legitimate opaque black artwork.
- Treat translucent grayscale layers as decorative effects only when they substantially overlap another page image; preserve standalone grayscale logos and diagrams.
- Deduplicate identical images within a page.
- Confirm a cross-page running header only after visually equivalent top-region content appears on at least three pages; keep two-page top content.
- Preserve identical non-header images on different pages.
- Use the source filename as the PDF document title, strip only an actual `.pdf` suffix, and preserve meaningful dots such as `manual.v2` for MIME-detected PDFs.
- Add a stable RAG H1 without duplicating a matching source title.
- Confirm repeated footer signatures from at least three PDF image boundaries before removing matching cross-page instances; preserve ordinary dated rows and standalone business dates.
- Treat newline-wrapped base64 data-image links as atomic RAG nodes so payload continuation text cannot contaminate the next image alt.
- Preserve repeated section headings and cross-page image references.
- Cache OSS uploads by MIME type and content hash while retaining every Markdown reference.
- Ignore generated `/output/` artifacts and use synthetic, document-independent test fixtures.

## Verification

- `GITHUB_ACTIONS=1 PATH=".../packages/markitdown/.venv/bin:$PATH" python -m pytest packages/markitdown/tests -q -k 'not test_html_path'`
  - 345 passed, 33 skipped, 1 deselected
- PDF-focused tests
  - 59 passed, 2 skipped
- `PYTHONPATH=packages/markitdown-api/src packages/markitdown-api/.venv/bin/python -m pytest packages/markitdown-api/tests -q`
  - 49 passed
- Black formatting and the commit hook passed.
- `git diff --check` passed.
- Real-world PDF conversion validation:
  - output Markdown and RAG SHA256 hashes unchanged from the accepted result
  - 58 image references and 55 unique image contents
  - 0 solid-black output images
  - repeated cross-page product references preserved
  - 55 simulated OSS uploads for 58 retained references
  - 0 embedded data URIs after simulated rewriting
  - repeated footer text and date-based image alt contamination removed

Remote-only URL, online HTML, proxy, and speech-service tests are skipped by the CI-equivalent local command because the current sandbox blocks those external services.

## Risks and Notes

- Running-header detection still uses page geometry and perceptual comparison, but requires matches on at least three distinct pages. Images outside the configured header region are never deduplicated across pages.
- Repeated footer removal requires at least three matching signatures at PDF image boundaries. Confirmed signatures are then removed across the document, including pages without extractable images.
- Decorative grayscale-effect filtering requires both a translucent grayscale soft mask and at least 90% geometric overlap with another page image.
- Low-opacity black-layer filtering applies only to solid-black images with readable soft masks and uses a conservative alpha threshold.
- JPEG images with transparency may be emitted as WebP; downstream consumers must support `image/webp`.
- A white image placed over a PDF vector background can have low contrast when extracted onto a white Markdown background; the converter does not rasterize vector page backgrounds.
- Generated files and the source validation document are intentionally excluded from this PR.
